### PR TITLE
SDCORE-453 : MongoDB slowness fix

### DIFF
--- a/configapi/api_sub_config.go
+++ b/configapi/api_sub_config.go
@@ -603,6 +603,9 @@ func PostSubscriberByID(c *gin.Context) {
 	amDataBsonM["ueId"] = ueId
 	amDataBsonM["servingPlmnId"] = servingPlmnId
 
+	delFilter := bson.M{"ueId": ueId, "servingPlmnId": servingPlmnId}
+	// Replace all data with new one
+	MongoDBLibrary.RestfulAPIDeleteMany(smDataColl, delFilter)
 	smDatasBsonA := make([]interface{}, 0, len(smDataData))
 	for _, smSubsData := range smDataData {
 		smDataBsonM := toBsonM(smSubsData)


### PR DESCRIPTION
Issue : For every CI run, the simapp adds 5000 entries into the DB. The web console doesn't check if the UE entry already exists and keeps adding. The CI helm chart also doesn't redeploy Mongo on every run. Thus, the number of entries in the DB keeps increasing. 
Fix : Delete all entries matching UEID and PLMNID in Mongo before adding new entry for the same. 
