### PR TITLE
Dev multi slice support

### DIFF
--- a/proto/server/clientEvtHandler.go
+++ b/proto/server/clientEvtHandler.go
@@ -794,7 +794,7 @@ func postConfigSpgw(client *clientNF) {
 			var upProf userPlaneProfile
 			userProfName := sliceName + "_up"
 			upProf.UserPlane = siteInfo.Upf["upf-name"].(string)
-			upProf.GlobalAddress = true
+			upProf.GlobalAddress = false
 			config.UserPlaneProfiles[userProfName] = &upProf
 			rule.SelectedUserPlaneProfile = userProfName
 


### PR DESCRIPTION
    Global address allocation from control plane needs to be disabled to support multiple
    slices at the same site.