### PR TITLE
upgrade apt-get to fix yarn build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ LABEL maintainer="ONF <omec-dev@opennetworking.org>"
 #RUN apt remove cmdtest yarn
 RUN apt-get update
 RUN apt-get -y install apt-transport-https ca-certificates
+RUN apt-get -y upgrade
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg > pubkey.gpg
 RUN apt-key add pubkey.gpg
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -


### PR DESCRIPTION
/usr/share/yarn/lib/cli.js:46280
  let {
      ^

SyntaxError: Unexpected token {
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/usr/share/yarn/bin/yarn.js:24:13)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)


to fix the yarn fail, we need to upgrade apt-get.