### PR TITLE
 qos rate fix to consider unit as Mbps

### DIFF
--- a/proto/server/clientEvtHandler.go
+++ b/proto/server/clientEvtHandler.go
@@ -987,6 +987,7 @@ func postConfigPcrf(client *clientNF) {
 					ruleQInfo.ApnAmbrDl = sliceConfig.Qos.Downlink
 				}
 				arp := &arpInfo{}
+				arp.Priority = int32((arpi & 0x3c) >> 2)
 				arp.PreEmptCap = (arpi & 0x40) >> 6
 				arp.PreEmpVulner = arpi & 0x1
 				ruleQInfo.Arp = arp


### PR DESCRIPTION
    Using default unit as Mbps in SD-Core for all QoS configuration

    Using default unit as Mbps in SD-Core for all QoS configuration
    1) UE qos configured at slice
    2) QoS configured at device Group level
    3) QoS configured at application level.

    Also if number overflows then using the max number.