### PR TITLE
Spurious IMSI delete from configpod

### DIFF
--- a/configapi/api_slice_mgmt.go
+++ b/configapi/api_slice_mgmt.go
@@ -95,7 +95,7 @@ func DeviceGroupPostHandler(c *gin.Context, msgOp int) bool {
 	}
 
 	var msg configmodels.ConfigMessage
-	msg.DevGroupName = groupName
+	procReq.DeviceGroupName = groupName
 	msg.MsgType = configmodels.Device_group
 	msg.MsgMethod = msgOp
 	msg.DevGroup = &procReq
@@ -177,14 +177,14 @@ func NetworkSlicePostHandler(c *gin.Context, msgOp int) bool {
 	denylist := procReq.DenyApplications
 	if len(denylist) > 0 {
 		configLog.Infof("Number of denied applications %v", len(denylist))
-		for _, d := range(denylist) {
+		for _, d := range denylist {
 			configLog.Infof("    deny application %v", d)
 		}
 	}
 	permitlist := procReq.PermitApplications
 	if len(permitlist) > 0 {
 		configLog.Infof("Number of permit applications %v", len(permitlist))
-		for _, p := range(permitlist) {
+		for _, p := range permitlist {
 			configLog.Infof("    permit application %v", p)
 		}
 	}
@@ -241,7 +241,7 @@ func NetworkSlicePostHandler(c *gin.Context, msgOp int) bool {
 
 	var msg configmodels.ConfigMessage
 	msg.MsgMethod = msgOp
-	msg.SliceName = sliceName
+	procReq.SliceName = sliceName
 	msg.MsgType = configmodels.Network_slice
 	msg.Slice = &procReq
 	msg.SliceName = sliceName

--- a/configapi/routers_subconfig.go
+++ b/configapi/routers_subconfig.go
@@ -6,8 +6,8 @@
 package configapi
 
 import (
-	"net/http"
 	"github.com/gin-gonic/gin"
+	"net/http"
 )
 
 func AddServiceSub(engine *gin.Engine) *gin.RouterGroup {

--- a/configmodels/model_slice_apn_ambr_qos.go
+++ b/configmodels/model_slice_apn_ambr_qos.go
@@ -15,7 +15,7 @@
 package configmodels
 
 type ApnAmbrQosInfo struct {
-	Uplink       int32    `json:"uplink-mbr,omitempty"`
-	Downlink     int32    `json:"downlink-mbr,omitempty"`
+	Uplink       int32  `json:"uplink-mbr,omitempty"`
+	Downlink     int32  `json:"downlink-mbr,omitempty"`
 	TrafficClass string `json:"traffic-class,omitempty"`
 }

--- a/configmodels/model_slice_site_info_g_node_bs.go
+++ b/configmodels/model_slice_site_info_g_node_bs.go
@@ -15,7 +15,6 @@
 package configmodels
 
 type SliceSiteInfoGNodeBs struct {
-
 	Name string `json:"name,omitempty"`
 
 	// unique tac per gNB. This should match gNB configuration.

--- a/configmodels/model_slice_site_info_plmn.go
+++ b/configmodels/model_slice_site_info_plmn.go
@@ -16,7 +16,6 @@ package configmodels
 
 // SliceSiteInfoPlmn - Fixed supported plmn at the site.
 type SliceSiteInfoPlmn struct {
-
 	Mcc string `json:"mcc,omitempty"`
 
 	Mnc string `json:"mnc,omitempty"`

--- a/configmodels/model_traffic_class.go
+++ b/configmodels/model_traffic_class.go
@@ -20,14 +20,14 @@ type TrafficClassInfo struct {
 	Name string `json:"name,omitempty"`
 
 	// QCI/5QI/QFI
-	Qci  int32 `json:"qci,omitempty"`
+	Qci int32 `json:"qci,omitempty"`
 
 	// Traffic class priority
-	Arp  int32 `json:"arp,omitempty"`
+	Arp int32 `json:"arp,omitempty"`
 
 	// Packet Delay Budget
-	Pdb  int32 `json:"pdb,omitempty"`
+	Pdb int32 `json:"pdb,omitempty"`
 
-    // Packet Error Loss Rate
-	Pelr  int32 `json:"pelr,omitempty"`
+	// Packet Error Loss Rate
+	Pelr int32 `json:"pelr,omitempty"`
 }


### PR DESCRIPTION


    IMSIs were deleted from HSS & re-added. Due to groupName not
    initialized in the DeviceGroupMessage