### PR TITLE
SDCORE-835: Issue with disable applications in a slice with DENY-ALL …

### DIFF
--- a/proto/server/clientEvtHandler.go
+++ b/proto/server/clientEvtHandler.go
@@ -616,13 +616,13 @@ func clientEventMachine(client *clientNF) {
 					dgnames := getDeleteGroupsList(slice, prevSlice)
 					for _, dgname := range dgnames {
 						dimsis := getDeletedImsisList(nil, client.devgroupsConfigClient[dgname])
-						sliceProto.DeletedImsis = dimsis
+						sliceProto.DeletedImsis = append(sliceProto.DeletedImsis, dimsis...)
 						sliceProto.OperationType = protos.OpType_SLICE_UPDATE
 					}
 					dgnames = getAddedGroupsList(slice, prevSlice)
 					for _, dgname := range dgnames {
 						aimsis := getAddedImsisList(client.devgroupsConfigClient[dgname], nil)
-						sliceProto.AddUpdatedImsis = aimsis
+						sliceProto.AddUpdatedImsis = append(sliceProto.AddUpdatedImsis, aimsis...)
 						sliceProto.OperationType = protos.OpType_SLICE_UPDATE
 					}
 					//updated other than device group list, adding all imsis because update is required for all
@@ -630,7 +630,7 @@ func clientEventMachine(client *clientNF) {
 						dgnames = getAddedGroupsList(slice, nil)
 						for _, dgname := range dgnames {
 							aimsis := getAddedImsisList(client.devgroupsConfigClient[dgname], nil)
-							sliceProto.AddUpdatedImsis = aimsis
+							sliceProto.AddUpdatedImsis = append(sliceProto.AddUpdatedImsis, aimsis...)
 							sliceProto.OperationType = protos.OpType_SLICE_UPDATE
 						}
 					}


### PR DESCRIPTION
…setting

This issue is seen only when networkslice has more than one device-group
Any Slice level update like pccrule add/update/delete happens,
AddUpdateImsis must have all imsis configured in device-groups
After Adding first device-group imsi list in AddUpdateImsis, this list is getting
replaced with next device-group imsi list. Hence, Slice change is updated only for one
device-group Imsis. Append Imsis Instead of replace solves the issue.