### PR TITLE
SDCORE-606: ConfigPod crash when non-existent slice is deleted

### DIFF
--- a/proto/server/clientEvtHandler.go
+++ b/proto/server/clientEvtHandler.go
@@ -498,6 +498,11 @@ func clientEventMachine(client *clientNF) {
 			} else if configMsg.SliceName != "" && configMsg.MsgMethod == configmodels.Delete_op {
 				lastSlice = client.slicesConfigClient[configMsg.SliceName]
 				client.clientLog.Infof("Received delete configuration for Slice: %v ", configMsg.SliceName)
+                //checking whether the slice is exist or not
+                if lastSlice == nil {
+                    client.clientLog.Warnf("Received non-exist slice: [%v] from Roc/Simapp",  configMsg.SliceName)
+                    continue
+                }
 				delete(client.slicesConfigClient, configMsg.SliceName)
 			}
 


### PR DESCRIPTION
If slice is not exist, prevSlice and CurrentSlice pointers are nil.
Added check not to access nil pointer if slice is not exist