### PR TITLE
Add GET operations for DeviceGroups and Network Slices

### DIFF
--- a/.github/workflows/run-webconsole-unit-tests.yml
+++ b/.github/workflows/run-webconsole-unit-tests.yml
@@ -1,5 +1,5 @@
+# SPDX-FileCopyrightText: 2023 Open Networking Foundation <info@opennetworking.org>
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Intel Corporation
 
 name: Unit tests
 

--- a/.github/workflows/run-webconsole-unit-tests.yml
+++ b/.github/workflows/run-webconsole-unit-tests.yml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 Intel Corporation
+
+name: Unit tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  unit-test-webconsole:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+
+      - name: Run unit tests for webconsole
+        run: |
+          make test

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ cscope.*
 bin/
 public/
 !/frontend/public/*.license
+.coverage/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.16.0-stretch AS builder
+FROM golang:1.16.0-buster AS builder
 
 LABEL maintainer="ONF <omec-dev@opennetworking.org>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.16.0-buster AS builder
+FROM golang:1.21-bookworm AS builder
 
 LABEL maintainer="ONF <omec-dev@opennetworking.org>"
 

--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,16 @@ docker-push:
 	for target in $(DOCKER_TARGETS); do \
                 docker push ${DOCKER_REGISTRY}${DOCKER_REPOSITORY}5gc-$$target:${DOCKER_TAG}; \
         done
+
+.coverage:
+	rm -rf $(CURDIR)/.coverage
+	mkdir -p $(CURDIR)/.coverage
+
+test: .coverage
+	docker run --rm -v $(CURDIR):/webconsole -w /webconsole golang:latest \
+		go test \
+			-failfast \
+			-coverprofile=.coverage/coverage-unit.txt \
+			-covermode=atomic \
+			-v \
+			./ ./...

--- a/configapi/api_default.go
+++ b/configapi/api_default.go
@@ -15,12 +15,50 @@
 package configapi
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/omec-project/MongoDBLibrary"
 	"github.com/omec-project/webconsole/backend/logger"
 	"github.com/omec-project/webconsole/configmodels"
+	"go.mongodb.org/mongo-driver/bson"
 )
+
+const (
+	devGroupDataColl = "webconsoleData.snapshots.devGroupData"
+	sliceDataColl    = "webconsoleData.snapshots.sliceData"
+)
+
+// GetDeviceGroups -
+func GetDeviceGroups(c *gin.Context) {
+	setCorsHeader(c)
+	logger.WebUILog.Infoln("Get all Device Groups")
+
+	var deviceGroups []configmodels.DeviceGroups = make([]configmodels.DeviceGroups, 0)
+	rawDeviceGroups := MongoDBLibrary.RestfulAPIGetMany(devGroupDataColl, bson.M{})
+	for _, rawDeviceGroup := range rawDeviceGroups {
+		tmp := configmodels.DeviceGroups{
+			DeviceGroupName: rawDeviceGroup["DeviceGroupName"].(string),
+		}
+		deviceGroups = append(deviceGroups, tmp)
+	}
+
+	c.JSON(http.StatusOK, deviceGroups)
+}
+
+// GetDeviceGroupsByName -
+func GetDeviceGroupByName(c *gin.Context) {
+	setCorsHeader(c)
+	logger.WebUILog.Infoln("Get Device Group by name")
+
+	var deviceGroup configmodels.DeviceGroups
+	filter := bson.M{"DeviceGroupName": c.Param("group-name")}
+	rawDeviceGroup := MongoDBLibrary.RestfulAPIGetOne(devGroupDataColl, filter)
+	json.Unmarshal(mapToByte(rawDeviceGroup), &deviceGroup)
+
+	c.JSON(http.StatusOK, deviceGroup)
+}
 
 // DeviceGroupGroupNameDelete -
 func DeviceGroupGroupNameDelete(c *gin.Context) {
@@ -56,6 +94,36 @@ func DeviceGroupGroupNamePost(c *gin.Context) {
 	} else {
 		c.JSON(http.StatusBadRequest, gin.H{})
 	}
+}
+
+// GetNetworkSlices -
+func GetNetworkSlices(c *gin.Context) {
+	setCorsHeader(c)
+	logger.WebUILog.Infoln("Get all Network Slices")
+
+	var networkSlices []configmodels.Slice = make([]configmodels.Slice, 0)
+	rawNetworkSlices := MongoDBLibrary.RestfulAPIGetMany(sliceDataColl, bson.M{})
+	for _, rawNetworkSlice := range rawNetworkSlices {
+		tmp := configmodels.Slice{
+			SliceName: rawNetworkSlice["SliceName"].(string),
+		}
+		networkSlices = append(networkSlices, tmp)
+	}
+
+	c.JSON(http.StatusOK, networkSlices)
+}
+
+// GetNetworkSliceByName -
+func GetNetworkSliceByName(c *gin.Context) {
+	setCorsHeader(c)
+	logger.WebUILog.Infoln("Get Network Slice by name")
+
+	var networkSlice configmodels.Slice
+	filter := bson.M{"SliceName": c.Param("slice-name")}
+	rawNetworkSlice := MongoDBLibrary.RestfulAPIGetOne(sliceDataColl, filter)
+	json.Unmarshal(mapToByte(rawNetworkSlice), &networkSlice)
+
+	c.JSON(http.StatusOK, networkSlice)
 }
 
 // NetworkSliceSliceNameDelete -

--- a/configapi/api_default.go
+++ b/configapi/api_default.go
@@ -43,7 +43,7 @@ func GetDeviceGroups(c *gin.Context) {
 	var deviceGroups []string = make([]string, 0)
 	rawDeviceGroups := RestfulAPIGetMany(devGroupDataColl, bson.M{})
 	for _, rawDeviceGroup := range rawDeviceGroups {
-		deviceGroups = append(deviceGroups, rawDeviceGroup["DeviceGroupName"].(string))
+		deviceGroups = append(deviceGroups, rawDeviceGroup["group-name"].(string))
 	}
 
 	c.JSON(http.StatusOK, deviceGroups)
@@ -55,7 +55,7 @@ func GetDeviceGroupByName(c *gin.Context) {
 	logger.WebUILog.Infoln("Get Device Group by name")
 
 	var deviceGroup configmodels.DeviceGroups
-	filter := bson.M{"DeviceGroupName": c.Param("group-name")}
+	filter := bson.M{"group-name": c.Param("group-name")}
 	rawDeviceGroup := RestfulAPIGetOne(devGroupDataColl, filter)
 	json.Unmarshal(mapToByte(rawDeviceGroup), &deviceGroup)
 

--- a/configapi/api_default.go
+++ b/configapi/api_default.go
@@ -43,7 +43,7 @@ func GetDeviceGroups(c *gin.Context) {
 	var deviceGroups []string = make([]string, 0)
 	rawDeviceGroups := RestfulAPIGetMany(devGroupDataColl, bson.M{})
 	for _, rawDeviceGroup := range rawDeviceGroups {
-		deviceGroups = append(deviceGroups, rawDeviceGroup["group-name"].(string))
+		deviceGroups = append(deviceGroups, rawDeviceGroup["DeviceGroupName"].(string))
 	}
 
 	c.JSON(http.StatusOK, deviceGroups)

--- a/configapi/api_default.go
+++ b/configapi/api_default.go
@@ -30,18 +30,20 @@ const (
 	sliceDataColl    = "webconsoleData.snapshots.sliceData"
 )
 
+var (
+	RestfulAPIGetMany = MongoDBLibrary.RestfulAPIGetMany
+	RestfulAPIGetOne  = MongoDBLibrary.RestfulAPIGetOne
+)
+
 // GetDeviceGroups -
 func GetDeviceGroups(c *gin.Context) {
 	setCorsHeader(c)
 	logger.WebUILog.Infoln("Get all Device Groups")
 
-	var deviceGroups []configmodels.DeviceGroups = make([]configmodels.DeviceGroups, 0)
-	rawDeviceGroups := MongoDBLibrary.RestfulAPIGetMany(devGroupDataColl, bson.M{})
+	var deviceGroups []string = make([]string, 0)
+	rawDeviceGroups := RestfulAPIGetMany(devGroupDataColl, bson.M{})
 	for _, rawDeviceGroup := range rawDeviceGroups {
-		tmp := configmodels.DeviceGroups{
-			DeviceGroupName: rawDeviceGroup["DeviceGroupName"].(string),
-		}
-		deviceGroups = append(deviceGroups, tmp)
+		deviceGroups = append(deviceGroups, rawDeviceGroup["DeviceGroupName"].(string))
 	}
 
 	c.JSON(http.StatusOK, deviceGroups)
@@ -54,10 +56,14 @@ func GetDeviceGroupByName(c *gin.Context) {
 
 	var deviceGroup configmodels.DeviceGroups
 	filter := bson.M{"DeviceGroupName": c.Param("group-name")}
-	rawDeviceGroup := MongoDBLibrary.RestfulAPIGetOne(devGroupDataColl, filter)
+	rawDeviceGroup := RestfulAPIGetOne(devGroupDataColl, filter)
 	json.Unmarshal(mapToByte(rawDeviceGroup), &deviceGroup)
 
-	c.JSON(http.StatusOK, deviceGroup)
+	if deviceGroup.DeviceGroupName == "" {
+		c.JSON(http.StatusNotFound, nil)
+	} else {
+		c.JSON(http.StatusOK, deviceGroup)
+	}
 }
 
 // DeviceGroupGroupNameDelete -
@@ -101,13 +107,10 @@ func GetNetworkSlices(c *gin.Context) {
 	setCorsHeader(c)
 	logger.WebUILog.Infoln("Get all Network Slices")
 
-	var networkSlices []configmodels.Slice = make([]configmodels.Slice, 0)
-	rawNetworkSlices := MongoDBLibrary.RestfulAPIGetMany(sliceDataColl, bson.M{})
+	var networkSlices []string = make([]string, 0)
+	rawNetworkSlices := RestfulAPIGetMany(sliceDataColl, bson.M{})
 	for _, rawNetworkSlice := range rawNetworkSlices {
-		tmp := configmodels.Slice{
-			SliceName: rawNetworkSlice["SliceName"].(string),
-		}
-		networkSlices = append(networkSlices, tmp)
+		networkSlices = append(networkSlices, rawNetworkSlice["SliceName"].(string))
 	}
 
 	c.JSON(http.StatusOK, networkSlices)
@@ -120,10 +123,14 @@ func GetNetworkSliceByName(c *gin.Context) {
 
 	var networkSlice configmodels.Slice
 	filter := bson.M{"SliceName": c.Param("slice-name")}
-	rawNetworkSlice := MongoDBLibrary.RestfulAPIGetOne(sliceDataColl, filter)
+	rawNetworkSlice := RestfulAPIGetOne(sliceDataColl, filter)
 	json.Unmarshal(mapToByte(rawNetworkSlice), &networkSlice)
 
-	c.JSON(http.StatusOK, networkSlice)
+	if networkSlice.SliceName == "" {
+		c.JSON(http.StatusNotFound, nil)
+	} else {
+		c.JSON(http.StatusOK, networkSlice)
+	}
 }
 
 // NetworkSliceSliceNameDelete -

--- a/configapi/api_default.go
+++ b/configapi/api_default.go
@@ -43,7 +43,7 @@ func GetDeviceGroups(c *gin.Context) {
 	var deviceGroups []string = make([]string, 0)
 	rawDeviceGroups := RestfulAPIGetMany(devGroupDataColl, bson.M{})
 	for _, rawDeviceGroup := range rawDeviceGroups {
-		deviceGroups = append(deviceGroups, rawDeviceGroup["DeviceGroupName"].(string))
+		deviceGroups = append(deviceGroups, rawDeviceGroup["group-name"].(string))
 	}
 
 	c.JSON(http.StatusOK, deviceGroups)

--- a/configapi/api_default_test.go
+++ b/configapi/api_default_test.go
@@ -174,7 +174,7 @@ func TestGetDeviceGroupByNameDoesExists(t *testing.T) {
 	}
 	body_bytes, _ := io.ReadAll(resp.Body)
 	body := string(body_bytes)
-	expected := `{"DeviceGroupName":"group1","imsis":["1234","5678"],"site-info":"demo","ip-domain-name":"pool1","ip-domain-expanded":{"dnn":"internet","ue-ip-pool":"172.250.1.0/16","dns-primary":"1.1.1.1","dns-secondary":"8.8.8.8","mtu":1460,"ue-dnn-qos":{"dnn-mbr-uplink":10000000,"dnn-mbr-downlink":10000000,"bitrate-unit":"kbps","traffic-class":{"name":"platinum","qci":8,"arp":6,"pdb":300,"pelr":6}}}}`
+	expected := `{"group-name":"group1","imsis":["1234","5678"],"site-info":"demo","ip-domain-name":"pool1","ip-domain-expanded":{"dnn":"internet","ue-ip-pool":"172.250.1.0/16","dns-primary":"1.1.1.1","dns-secondary":"8.8.8.8","mtu":1460,"ue-dnn-qos":{"dnn-mbr-uplink":10000000,"dnn-mbr-downlink":10000000,"bitrate-unit":"kbps","traffic-class":{"name":"platinum","qci":8,"arp":6,"pdb":300,"pelr":6}}}}`
 	if body != expected {
 		t.Errorf("Expected %v, got %v", expected, body)
 	}

--- a/configapi/api_default_test.go
+++ b/configapi/api_default_test.go
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2023 Open Networking Foundation <info@opennetworking.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 package configapi
 
 import (

--- a/configapi/api_default_test.go
+++ b/configapi/api_default_test.go
@@ -1,0 +1,349 @@
+package configapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/omec-project/webconsole/configmodels"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func deviceGroup(name string) configmodels.DeviceGroups {
+	traffic_class := configmodels.TrafficClassInfo{
+		Name: "platinum",
+		Qci:  8,
+		Arp:  6,
+		Pdb:  300,
+		Pelr: 6,
+	}
+	qos := configmodels.DeviceGroupsIpDomainExpandedUeDnnQos{
+		DnnMbrUplink:   10000000,
+		DnnMbrDownlink: 10000000,
+		BitrateUnit:    "kbps",
+		TrafficClass:   &traffic_class,
+	}
+	ipdomain := configmodels.DeviceGroupsIpDomainExpanded{
+		Dnn:          "internet",
+		UeIpPool:     "172.250.1.0/16",
+		DnsPrimary:   "1.1.1.1",
+		DnsSecondary: "8.8.8.8",
+		Mtu:          1460,
+		UeDnnQos:     &qos,
+	}
+	deviceGroup := configmodels.DeviceGroups{
+		DeviceGroupName:  name,
+		Imsis:            []string{"1234", "5678"},
+		SiteInfo:         "demo",
+		IpDomainName:     "pool1",
+		IpDomainExpanded: ipdomain,
+	}
+	return deviceGroup
+}
+
+func noDeviceGroups(coll string, filter bson.M) []map[string]interface{} {
+	var results []map[string]interface{}
+	return results
+}
+
+func oneDeviceGroups(coll string, filter bson.M) []map[string]interface{} {
+	var results []map[string]interface{}
+	dg := deviceGroup("group1")
+	var dgbson bson.M
+	tmp, _ := json.Marshal(dg)
+	json.Unmarshal(tmp, &dgbson)
+
+	results = append(results, dgbson)
+	return results
+}
+
+func manyDeviceGroups(coll string, filter bson.M) []map[string]interface{} {
+	var results []map[string]interface{}
+	var names = []string{"group1", "group2", "group3"}
+	for _, name := range names {
+		dg := deviceGroup(name)
+		var dgbson bson.M
+		tmp, _ := json.Marshal(dg)
+		json.Unmarshal(tmp, &dgbson)
+
+		results = append(results, dgbson)
+	}
+	return results
+}
+
+func notFoundDeviceGroup(coll string, filter bson.M) map[string]interface{} {
+	return nil
+}
+
+func foundDeviceGroup(coll string, filter bson.M) map[string]interface{} {
+	dg := deviceGroup("group1")
+	var dgbson bson.M
+	tmp, _ := json.Marshal(dg)
+	json.Unmarshal(tmp, &dgbson)
+	return dgbson
+}
+
+func TestGetDeviceGroupsNoGroups(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	RestfulAPIGetMany = noDeviceGroups
+	GetDeviceGroups(c)
+	resp := w.Result()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+	}
+	body_bytes, _ := io.ReadAll(resp.Body)
+	body := string(body_bytes)
+	if body != "[]" {
+		t.Fatalf("Expected empty JSON list, got %v", body)
+	}
+}
+
+func TestGetDeviceGroupsOneGroup(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	RestfulAPIGetMany = oneDeviceGroups
+	GetDeviceGroups(c)
+	resp := w.Result()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+	}
+	body_bytes, _ := io.ReadAll(resp.Body)
+	body := string(body_bytes)
+	expected := `["group1"]`
+	if body != expected {
+		t.Fatalf("Expected %v, got %v", expected, body)
+	}
+}
+
+func TestGetDeviceGroupsManyGroup(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	RestfulAPIGetMany = manyDeviceGroups
+	GetDeviceGroups(c)
+	resp := w.Result()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+	}
+	body_bytes, _ := io.ReadAll(resp.Body)
+	body := string(body_bytes)
+	expected := `["group1","group2","group3"]`
+	if body != expected {
+		t.Fatalf("Expected %v, got %v", expected, body)
+	}
+}
+
+func TestGetDeviceGroupByNameDoesNotExist(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	RestfulAPIGetOne = notFoundDeviceGroup
+	c.Params = append(c.Params, gin.Param{Key: "device-name", Value: "group1"})
+	GetDeviceGroupByName(c)
+	resp := w.Result()
+
+	if resp.StatusCode != 404 {
+		t.Fatalf("Expected StatusCode %d, got %d", 404, resp.StatusCode)
+	}
+	body_bytes, _ := io.ReadAll(resp.Body)
+	body := string(body_bytes)
+	if body != "null" {
+		t.Fatalf("Expected %v, got %v", "null", body)
+	}
+}
+
+func TestGetDeviceGroupByNameDoesExists(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	RestfulAPIGetOne = foundDeviceGroup
+	c.Params = append(c.Params, gin.Param{Key: "device-name", Value: "group1"})
+	GetDeviceGroupByName(c)
+	resp := w.Result()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+	}
+	body_bytes, _ := io.ReadAll(resp.Body)
+	body := string(body_bytes)
+	expected := `{"DeviceGroupName":"group1","imsis":["1234","5678"],"site-info":"demo","ip-domain-name":"pool1","ip-domain-expanded":{"dnn":"internet","ue-ip-pool":"172.250.1.0/16","dns-primary":"1.1.1.1","dns-secondary":"8.8.8.8","mtu":1460,"ue-dnn-qos":{"dnn-mbr-uplink":10000000,"dnn-mbr-downlink":10000000,"bitrate-unit":"kbps","traffic-class":{"name":"platinum","qci":8,"arp":6,"pdb":300,"pelr":6}}}}`
+	if body != expected {
+		t.Fatalf("Expected %v, got %v", expected, body)
+	}
+}
+
+func networkSlice(name string) configmodels.Slice {
+	upf := make(map[string]interface{}, 0)
+	upf["upf-name"] = "upf"
+	upf["upf-port"] = "8805"
+	plmn := configmodels.SliceSiteInfoPlmn{
+		Mcc: "208",
+		Mnc: "93",
+	}
+	gnodeb := configmodels.SliceSiteInfoGNodeBs{
+		Name: "demo-gnb1",
+		Tac:  1,
+	}
+	slice_id := configmodels.SliceSliceId{
+		Sst: "1",
+		Sd:  "010203",
+	}
+	site_info := configmodels.SliceSiteInfo{
+		SiteName: "demo",
+		Plmn:     plmn,
+		GNodeBs:  []configmodels.SliceSiteInfoGNodeBs{gnodeb},
+		Upf:      upf,
+	}
+	slice := configmodels.Slice{
+		SliceName:       name,
+		SliceId:         slice_id,
+		SiteDeviceGroup: []string{"group1", "group2"},
+		SiteInfo:        site_info,
+	}
+	return slice
+}
+
+func noNetworkSlices(coll string, filter bson.M) []map[string]interface{} {
+	var results []map[string]interface{}
+	return results
+}
+
+func oneNetworkSlice(coll string, filter bson.M) []map[string]interface{} {
+	var results []map[string]interface{}
+	ns := networkSlice("slice1")
+	var slicebson bson.M
+	tmp, _ := json.Marshal(ns)
+	json.Unmarshal(tmp, &slicebson)
+
+	results = append(results, slicebson)
+	return results
+}
+
+func manyNetworkSlices(coll string, filter bson.M) []map[string]interface{} {
+	var results []map[string]interface{}
+	var names = []string{"slice1", "slice2", "slice3"}
+	for _, name := range names {
+		ns := networkSlice(name)
+		var slicebson bson.M
+		tmp, _ := json.Marshal(ns)
+		json.Unmarshal(tmp, &slicebson)
+
+		results = append(results, slicebson)
+	}
+	return results
+}
+
+func notFoundNetworkSlice(coll string, filter bson.M) map[string]interface{} {
+	return nil
+}
+
+func foundNetworkSlice(coll string, filter bson.M) map[string]interface{} {
+	ns := networkSlice("slice1")
+	var slicebson bson.M
+	tmp, _ := json.Marshal(ns)
+	json.Unmarshal(tmp, &slicebson)
+	return slicebson
+}
+
+func TestGetNetworkSlicesNoSlices(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	RestfulAPIGetMany = noNetworkSlices
+	GetNetworkSlices(c)
+	resp := w.Result()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+	}
+	body_bytes, _ := io.ReadAll(resp.Body)
+	body := string(body_bytes)
+	if body != "[]" {
+		t.Fatalf("Expected empty JSON list, got %v", body)
+	}
+}
+
+func TestGetNetworkSlicesOneSlice(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	RestfulAPIGetMany = oneNetworkSlice
+	GetNetworkSlices(c)
+	resp := w.Result()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+	}
+	body_bytes, _ := io.ReadAll(resp.Body)
+	body := string(body_bytes)
+	expected := `["slice1"]`
+	if body != expected {
+		t.Fatalf("Expected %v, got %v", expected, body)
+	}
+}
+
+func TestGetNetworkSlicesManySlices(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	RestfulAPIGetMany = manyNetworkSlices
+	GetNetworkSlices(c)
+	resp := w.Result()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+	}
+	body_bytes, _ := io.ReadAll(resp.Body)
+	body := string(body_bytes)
+	expected := `["slice1","slice2","slice3"]`
+	if body != expected {
+		t.Fatalf("Expected %v, got %v", expected, body)
+	}
+}
+
+func TestGetNetworkSliceByNameDoesNotExist(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	RestfulAPIGetOne = notFoundNetworkSlice
+	c.Params = append(c.Params, gin.Param{Key: "slice-name", Value: "slice1"})
+	GetNetworkSliceByName(c)
+	resp := w.Result()
+
+	if resp.StatusCode != 404 {
+		t.Fatalf("Expected StatusCode %d, got %d", 404, resp.StatusCode)
+	}
+	body_bytes, _ := io.ReadAll(resp.Body)
+	body := string(body_bytes)
+	if body != "null" {
+		t.Fatalf("Expected %v, got %v", "null", body)
+	}
+}
+
+func TestGetNetworkSliceByNameDoesExists(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	RestfulAPIGetOne = foundNetworkSlice
+	c.Params = append(c.Params, gin.Param{Key: "slice-name", Value: "slice1"})
+	GetNetworkSliceByName(c)
+	resp := w.Result()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+	}
+	body_bytes, _ := io.ReadAll(resp.Body)
+	body := string(body_bytes)
+	expected := `{"SliceName":"slice1","slice-id":{"sst":"1","sd":"010203"},"site-device-group":["group1","group2"],"site-info":{"site-name":"demo","plmn":{"mcc":"208","mnc":"93"},"gNodeBs":[{"name":"demo-gnb1","tac":1}],"upf":{"upf-name":"upf","upf-port":"8805"}}}`
+	if body != expected {
+		t.Fatalf("Expected %v, got %v", expected, body)
+	}
+}

--- a/configapi/api_default_test.go
+++ b/configapi/api_default_test.go
@@ -179,7 +179,7 @@ func TestGetDeviceGroupByNameDoesExists(t *testing.T) {
 	}
 	body_bytes, _ := io.ReadAll(resp.Body)
 	body := string(body_bytes)
-	expected := `{"group-name":"group1","imsis":["1234","5678"],"site-info":"demo","ip-domain-name":"pool1","ip-domain-expanded":{"dnn":"internet","ue-ip-pool":"172.250.1.0/16","dns-primary":"1.1.1.1","dns-secondary":"8.8.8.8","mtu":1460,"ue-dnn-qos":{"dnn-mbr-uplink":10000000,"dnn-mbr-downlink":10000000,"bitrate-unit":"kbps","traffic-class":{"name":"platinum","qci":8,"arp":6,"pdb":300,"pelr":6}}}}`
+	expected := `{"DeviceGroupName":"group1","imsis":["1234","5678"],"site-info":"demo","ip-domain-name":"pool1","ip-domain-expanded":{"dnn":"internet","ue-ip-pool":"172.250.1.0/16","dns-primary":"1.1.1.1","dns-secondary":"8.8.8.8","mtu":1460,"ue-dnn-qos":{"dnn-mbr-uplink":10000000,"dnn-mbr-downlink":10000000,"bitrate-unit":"kbps","traffic-class":{"name":"platinum","qci":8,"arp":6,"pdb":300,"pelr":6}}}}`
 	if body != expected {
 		t.Errorf("Expected %v, got %v", expected, body)
 	}

--- a/configapi/api_default_test.go
+++ b/configapi/api_default_test.go
@@ -179,7 +179,7 @@ func TestGetDeviceGroupByNameDoesExists(t *testing.T) {
 	}
 	body_bytes, _ := io.ReadAll(resp.Body)
 	body := string(body_bytes)
-	expected := `{"DeviceGroupName":"group1","imsis":["1234","5678"],"site-info":"demo","ip-domain-name":"pool1","ip-domain-expanded":{"dnn":"internet","ue-ip-pool":"172.250.1.0/16","dns-primary":"1.1.1.1","dns-secondary":"8.8.8.8","mtu":1460,"ue-dnn-qos":{"dnn-mbr-uplink":10000000,"dnn-mbr-downlink":10000000,"bitrate-unit":"kbps","traffic-class":{"name":"platinum","qci":8,"arp":6,"pdb":300,"pelr":6}}}}`
+	expected := `{"group-name":"group1","imsis":["1234","5678"],"site-info":"demo","ip-domain-name":"pool1","ip-domain-expanded":{"dnn":"internet","ue-ip-pool":"172.250.1.0/16","dns-primary":"1.1.1.1","dns-secondary":"8.8.8.8","mtu":1460,"ue-dnn-qos":{"dnn-mbr-uplink":10000000,"dnn-mbr-downlink":10000000,"bitrate-unit":"kbps","traffic-class":{"name":"platinum","qci":8,"arp":6,"pdb":300,"pelr":6}}}}`
 	if body != expected {
 		t.Errorf("Expected %v, got %v", expected, body)
 	}

--- a/configapi/api_default_test.go
+++ b/configapi/api_default_test.go
@@ -94,12 +94,12 @@ func TestGetDeviceGroupsNoGroups(t *testing.T) {
 	resp := w.Result()
 
 	if resp.StatusCode != 200 {
-		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+		t.Errorf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
 	}
 	body_bytes, _ := io.ReadAll(resp.Body)
 	body := string(body_bytes)
 	if body != "[]" {
-		t.Fatalf("Expected empty JSON list, got %v", body)
+		t.Errorf("Expected empty JSON list, got %v", body)
 	}
 }
 
@@ -112,13 +112,13 @@ func TestGetDeviceGroupsOneGroup(t *testing.T) {
 	resp := w.Result()
 
 	if resp.StatusCode != 200 {
-		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+		t.Errorf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
 	}
 	body_bytes, _ := io.ReadAll(resp.Body)
 	body := string(body_bytes)
 	expected := `["group1"]`
 	if body != expected {
-		t.Fatalf("Expected %v, got %v", expected, body)
+		t.Errorf("Expected %v, got %v", expected, body)
 	}
 }
 
@@ -131,13 +131,13 @@ func TestGetDeviceGroupsManyGroup(t *testing.T) {
 	resp := w.Result()
 
 	if resp.StatusCode != 200 {
-		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+		t.Errorf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
 	}
 	body_bytes, _ := io.ReadAll(resp.Body)
 	body := string(body_bytes)
 	expected := `["group1","group2","group3"]`
 	if body != expected {
-		t.Fatalf("Expected %v, got %v", expected, body)
+		t.Errorf("Expected %v, got %v", expected, body)
 	}
 }
 
@@ -151,12 +151,12 @@ func TestGetDeviceGroupByNameDoesNotExist(t *testing.T) {
 	resp := w.Result()
 
 	if resp.StatusCode != 404 {
-		t.Fatalf("Expected StatusCode %d, got %d", 404, resp.StatusCode)
+		t.Errorf("Expected StatusCode %d, got %d", 404, resp.StatusCode)
 	}
 	body_bytes, _ := io.ReadAll(resp.Body)
 	body := string(body_bytes)
 	if body != "null" {
-		t.Fatalf("Expected %v, got %v", "null", body)
+		t.Errorf("Expected %v, got %v", "null", body)
 	}
 }
 
@@ -170,13 +170,13 @@ func TestGetDeviceGroupByNameDoesExists(t *testing.T) {
 	resp := w.Result()
 
 	if resp.StatusCode != 200 {
-		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+		t.Errorf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
 	}
 	body_bytes, _ := io.ReadAll(resp.Body)
 	body := string(body_bytes)
 	expected := `{"DeviceGroupName":"group1","imsis":["1234","5678"],"site-info":"demo","ip-domain-name":"pool1","ip-domain-expanded":{"dnn":"internet","ue-ip-pool":"172.250.1.0/16","dns-primary":"1.1.1.1","dns-secondary":"8.8.8.8","mtu":1460,"ue-dnn-qos":{"dnn-mbr-uplink":10000000,"dnn-mbr-downlink":10000000,"bitrate-unit":"kbps","traffic-class":{"name":"platinum","qci":8,"arp":6,"pdb":300,"pelr":6}}}}`
 	if body != expected {
-		t.Fatalf("Expected %v, got %v", expected, body)
+		t.Errorf("Expected %v, got %v", expected, body)
 	}
 }
 
@@ -262,12 +262,12 @@ func TestGetNetworkSlicesNoSlices(t *testing.T) {
 	resp := w.Result()
 
 	if resp.StatusCode != 200 {
-		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+		t.Errorf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
 	}
 	body_bytes, _ := io.ReadAll(resp.Body)
 	body := string(body_bytes)
 	if body != "[]" {
-		t.Fatalf("Expected empty JSON list, got %v", body)
+		t.Errorf("Expected empty JSON list, got %v", body)
 	}
 }
 
@@ -280,13 +280,13 @@ func TestGetNetworkSlicesOneSlice(t *testing.T) {
 	resp := w.Result()
 
 	if resp.StatusCode != 200 {
-		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+		t.Errorf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
 	}
 	body_bytes, _ := io.ReadAll(resp.Body)
 	body := string(body_bytes)
 	expected := `["slice1"]`
 	if body != expected {
-		t.Fatalf("Expected %v, got %v", expected, body)
+		t.Errorf("Expected %v, got %v", expected, body)
 	}
 }
 
@@ -299,13 +299,13 @@ func TestGetNetworkSlicesManySlices(t *testing.T) {
 	resp := w.Result()
 
 	if resp.StatusCode != 200 {
-		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+		t.Errorf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
 	}
 	body_bytes, _ := io.ReadAll(resp.Body)
 	body := string(body_bytes)
 	expected := `["slice1","slice2","slice3"]`
 	if body != expected {
-		t.Fatalf("Expected %v, got %v", expected, body)
+		t.Errorf("Expected %v, got %v", expected, body)
 	}
 }
 
@@ -319,12 +319,12 @@ func TestGetNetworkSliceByNameDoesNotExist(t *testing.T) {
 	resp := w.Result()
 
 	if resp.StatusCode != 404 {
-		t.Fatalf("Expected StatusCode %d, got %d", 404, resp.StatusCode)
+		t.Errorf("Expected StatusCode %d, got %d", 404, resp.StatusCode)
 	}
 	body_bytes, _ := io.ReadAll(resp.Body)
 	body := string(body_bytes)
 	if body != "null" {
-		t.Fatalf("Expected %v, got %v", "null", body)
+		t.Errorf("Expected %v, got %v", "null", body)
 	}
 }
 
@@ -338,12 +338,12 @@ func TestGetNetworkSliceByNameDoesExists(t *testing.T) {
 	resp := w.Result()
 
 	if resp.StatusCode != 200 {
-		t.Fatalf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
+		t.Errorf("Expected StatusCode %d, got %d", 200, resp.StatusCode)
 	}
 	body_bytes, _ := io.ReadAll(resp.Body)
 	body := string(body_bytes)
 	expected := `{"SliceName":"slice1","slice-id":{"sst":"1","sd":"010203"},"site-device-group":["group1","group2"],"site-info":{"site-name":"demo","plmn":{"mcc":"208","mnc":"93"},"gNodeBs":[{"name":"demo-gnb1","tac":1}],"upf":{"upf-name":"upf","upf-port":"8805"}}}`
 	if body != expected {
-		t.Fatalf("Expected %v, got %v", expected, body)
+		t.Errorf("Expected %v, got %v", expected, body)
 	}
 }

--- a/configapi/api_slice_mgmt.go
+++ b/configapi/api_slice_mgmt.go
@@ -7,6 +7,7 @@ package configapi
 
 import (
 	"math"
+	"slices"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -178,6 +179,8 @@ func NetworkSlicePostHandler(c *gin.Context, msgOp int) bool {
 	configLog.Infof("  sd          : %v", slice.Sd)
 
 	group := procReq.SiteDeviceGroup
+	slices.Sort(group)
+	slices.Compact(group)
 	configLog.Infof("Number of device groups %v", len(group))
 	for i := 0; i < len(group); i++ {
 		configLog.Infof("  device groups(%v) - %v \n", i+1, group[i])

--- a/configapi/api_slice_mgmt.go
+++ b/configapi/api_slice_mgmt.go
@@ -9,8 +9,8 @@ import (
 	"math"
 	"strings"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/gin-gonic/gin"
+	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/webconsole/backend/logger"
 	"github.com/omec-project/webconsole/configmodels"
 	"github.com/sirupsen/logrus"
@@ -79,7 +79,7 @@ func DeviceGroupPostHandler(c *gin.Context, msgOp int) bool {
 		err = c.ShouldBindJSON(&request)
 	}
 	if err != nil {
-		configLog.Infof(" err ", err)
+		configLog.Infof(" err %v", err)
 		return false
 	}
 	req := http_wrapper.NewRequest(c.Request, request)
@@ -157,7 +157,7 @@ func NetworkSlicePostHandler(c *gin.Context, msgOp int) bool {
 		err = c.ShouldBindJSON(&request)
 	}
 	if err != nil {
-		configLog.Infof(" err ", err)
+		configLog.Infof(" err %v", err)
 		return false
 	}
 	//configLog.Infof("Printing request full after binding : %v ", request)

--- a/configapi/routers.go
+++ b/configapi/routers.go
@@ -70,6 +70,20 @@ var routes = Routes{
 	},
 
 	{
+		"GetDeviceGroups",
+		http.MethodGet,
+		"/device-group",
+		GetDeviceGroups,
+	},
+
+	{
+		"GetDeviceGroupByName",
+		http.MethodGet,
+		"/device-group/:group-name",
+		GetDeviceGroupByName,
+	},
+
+	{
 		"DeviceGroupGroupNameDelete",
 		http.MethodDelete,
 		"/device-group/:group-name",
@@ -95,6 +109,20 @@ var routes = Routes{
 		http.MethodPost,
 		"/device-group/:group-name",
 		DeviceGroupGroupNamePost,
+	},
+
+	{
+		"GetNetworkSlices",
+		http.MethodGet,
+		"/network-slice",
+		GetNetworkSlices,
+	},
+
+	{
+		"GetNetworkSliceByName",
+		http.MethodGet,
+		"/network-slice/:slice-name",
+		GetNetworkSliceByName,
 	},
 
 	{

--- a/configmodels/model_device_groups.go
+++ b/configmodels/model_device_groups.go
@@ -15,7 +15,7 @@
 package configmodels
 
 type DeviceGroups struct {
-	DeviceGroupName string
+	DeviceGroupName string `json:"group-name,omitempty"`
 
 	Imsis []string `json:"imsis"`
 

--- a/configmodels/model_device_groups.go
+++ b/configmodels/model_device_groups.go
@@ -15,9 +15,9 @@
 package configmodels
 
 type DeviceGroups struct {
-	DeviceGroupName string `json:group-name,omitempty"`
+	DeviceGroupName string
 
-	Imsis []string `json:"imsis,omitempty"`
+	Imsis []string `json:"imsis"`
 
 	SiteInfo string `json:"site-info,omitempty"`
 

--- a/configmodels/model_device_groups.go
+++ b/configmodels/model_device_groups.go
@@ -15,7 +15,7 @@
 package configmodels
 
 type DeviceGroups struct {
-	DeviceGroupName string `json:"group-name,omitempty"`
+	DeviceGroupName string
 
 	Imsis []string `json:"imsis"`
 

--- a/configmodels/model_device_groups.go
+++ b/configmodels/model_device_groups.go
@@ -15,7 +15,7 @@
 package configmodels
 
 type DeviceGroups struct {
-	DeviceGroupName string
+	DeviceGroupName string `json:"group-name"`
 
 	Imsis []string `json:"imsis"`
 

--- a/configmodels/model_slice.go
+++ b/configmodels/model_slice.go
@@ -19,7 +19,7 @@ type Slice struct {
 
 	SliceId SliceSliceId `json:"slice-id,omitempty"`
 
-	SiteDeviceGroup []string `json:"site-device-group,omitempty"`
+	SiteDeviceGroup []string `json:"site-device-group"`
 
 	SiteInfo SliceSiteInfo `json:"site-info,omitempty"`
 

--- a/configmodels/model_slice_site_info.go
+++ b/configmodels/model_slice_site_info.go
@@ -22,7 +22,7 @@ type SliceSiteInfo struct {
 
 	Plmn SliceSiteInfoPlmn `json:"plmn,omitempty"`
 
-	GNodeBs []SliceSiteInfoGNodeBs `json:"gNodeBs,omitempty"`
+	GNodeBs []SliceSiteInfoGNodeBs `json:"gNodeBs"`
 
 	// UPF which belong to this slice
 	Upf map[string]interface{} `json:"upf,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/omec-project/webconsole
 
-go 1.16
+go 1.21
 
 require (
 	github.com/antonfisher/nested-logrus-formatter v1.3.1
@@ -21,4 +21,38 @@ require (
 	google.golang.org/grpc v1.39.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/evanphx/json-patch v4.9.0+incompatible // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
+	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/go-playground/validator/v10 v10.4.1 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/golang-jwt/jwt v3.2.1+incompatible // indirect
+	github.com/golang/protobuf v1.5.0 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/leodido/go-urn v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/ugorji/go/codec v1.2.1 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.0.2 // indirect
+	github.com/xdg-go/stringprep v1.0.2 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
+	golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9 // indirect
+	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
+	golang.org/x/sys v0.0.0-20210423082822-04245dca01da // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/genproto v0.0.0-20200825200019-8632dd797987 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -259,7 +259,6 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
-github.com/ugorji/go v1.2.1 h1:dz+JxTe7GZQdErTo7SREc1jQj/hFP1k7jyIAwODoW+k=
 github.com/ugorji/go v1.2.1/go.mod h1:cSVypSfTLm2o9fKxXvQgn3rMmkPXovcWor6Qn5tbFmI=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/ugorji/go/codec v1.2.1 h1:/TRfW3XKkvWvmAYyCUaQlhoCDGjcvNR8xVVA/l5p/jQ=

--- a/proto/server/clientEvtHandler.go
+++ b/proto/server/clientEvtHandler.go
@@ -298,7 +298,7 @@ func fillSlice(client *clientNF, sliceName string, sliceConf *configmodels.Slice
 		client.clientLog.Debugf("group %v, len of devgroupsConfigClient %v ", group, len(client.devgroupsConfigClient))
 		devGroupConfig := client.devgroupsConfigClient[group]
 		if devGroupConfig == nil {
-			client.clientLog.Infoln("Did not find group %v ", group)
+			client.clientLog.Infof("Did not find group %v ", group)
 			return false
 		}
 

--- a/proto/server/clientEvtHandler.go
+++ b/proto/server/clientEvtHandler.go
@@ -37,7 +37,7 @@ type clientNF struct {
 	metadataReqtd         bool
 }
 
-//message format received from grpc server thread to Client go routine
+// message format received from grpc server thread to Client go routine
 type clientReqMsg struct {
 	networkSliceReqMsg *protos.NetworkSliceRequest
 	grpcRspMsg         chan *clientRspMsg
@@ -48,7 +48,7 @@ type clientReqMsg struct {
 	slice              *configmodels.Slice
 }
 
-//message format to send response from client go routine to grpc server
+// message format to send response from client go routine to grpc server
 type clientRspMsg struct {
 	networkSliceRspMsg *protos.NetworkSliceResponse
 }
@@ -224,11 +224,11 @@ func getClient(id string) (*clientNF, bool) {
 	client.devgroupsConfigClient = make(map[string]*configmodels.DeviceGroups)
 	// TODO : should we lock global tables before copying them ?
 	rwLock.RLock()
-	for key, value := range slicesConfigSnapshot {
-		client.slicesConfigClient[key] = value
+	for _, value := range getSlices() {
+		client.slicesConfigClient[value.SliceName] = value
 	}
-	for key, value := range devgroupsConfigSnapshot {
-		client.devgroupsConfigClient[key] = value
+	for _, value := range getDeviceGroups() {
+		client.devgroupsConfigClient[value.DeviceGroupName] = value
 	}
 	rwLock.RUnlock()
 	go clientEventMachine(client)

--- a/proto/server/configEvtHandler.go
+++ b/proto/server/configEvtHandler.go
@@ -132,7 +132,7 @@ func configHandler(configMsgChan chan *configmodels.ConfigMessage, configReceive
 					if configMsg.DevGroup == nil {
 						configLog.Infof("Received delete Device Group [%v] from config channel", configMsg.DevGroupName)
 						config5gMsg.PrevDevGroup = getDeviceGroupByName(configMsg.DevGroupName)
-						filter := bson.M{"DeviceGroupName": configMsg.DevGroupName}
+						filter := bson.M{"group-name": configMsg.DevGroupName}
 						RestfulAPIDeleteOne(devGroupDataColl, filter)
 					}
 
@@ -171,7 +171,7 @@ func handleDeviceGroupPost(configMsg *configmodels.ConfigMessage, subsUpdateChan
 		config5gMsg.PrevDevGroup = getDeviceGroupByName(configMsg.DevGroupName)
 		subsUpdateChan <- &config5gMsg
 	}
-	filter := bson.M{"DeviceGroupName": configMsg.DevGroupName}
+	filter := bson.M{"group-name": configMsg.DevGroupName}
 	devGroupDataBsonA := toBsonM(configMsg.DevGroup)
 	RestfulAPIPost(devGroupDataColl, filter, devGroupDataBsonA)
 	rwLock.Unlock()
@@ -203,7 +203,7 @@ func getDeviceGroups() []*configmodels.DeviceGroups {
 }
 
 func getDeviceGroupByName(name string) *configmodels.DeviceGroups {
-	filter := bson.M{"DeviceGroupName": name}
+	filter := bson.M{"group-name": name}
 	devGroupDataInterface := RestfulAPIGetOne(devGroupDataColl, filter)
 	var devGroupData configmodels.DeviceGroups
 	json.Unmarshal(mapToByte(devGroupDataInterface), &devGroupData)

--- a/proto/server/configEvtHandler_test.go
+++ b/proto/server/configEvtHandler_test.go
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2023 Open Networking Foundation <info@opennetworking.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 package server
 
 import (

--- a/proto/server/configEvtHandler_test.go
+++ b/proto/server/configEvtHandler_test.go
@@ -1,0 +1,269 @@
+package server
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/omec-project/webconsole/backend/factory"
+	"github.com/omec-project/webconsole/configmodels"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+var postData []map[string]interface{}
+
+func deviceGroup(name string) configmodels.DeviceGroups {
+	traffic_class := configmodels.TrafficClassInfo{
+		Name: "platinum",
+		Qci:  8,
+		Arp:  6,
+		Pdb:  300,
+		Pelr: 6,
+	}
+	qos := configmodels.DeviceGroupsIpDomainExpandedUeDnnQos{
+		DnnMbrUplink:   10000000,
+		DnnMbrDownlink: 10000000,
+		BitrateUnit:    "kbps",
+		TrafficClass:   &traffic_class,
+	}
+	ipdomain := configmodels.DeviceGroupsIpDomainExpanded{
+		Dnn:          "internet",
+		UeIpPool:     "172.250.1.0/16",
+		DnsPrimary:   "1.1.1.1",
+		DnsSecondary: "8.8.8.8",
+		Mtu:          1460,
+		UeDnnQos:     &qos,
+	}
+	deviceGroup := configmodels.DeviceGroups{
+		DeviceGroupName:  name,
+		Imsis:            []string{"1234", "5678"},
+		SiteInfo:         "demo",
+		IpDomainName:     "pool1",
+		IpDomainExpanded: ipdomain,
+	}
+	return deviceGroup
+}
+
+func fakeMongoPost(coll string, filter primitive.M, data map[string]interface{}) bool {
+	params := map[string]interface{}{
+		"coll":   coll,
+		"filter": filter,
+		"data":   data,
+	}
+	postData = append(postData, params)
+	return true
+}
+
+func fakeMongoGetOne(value map[string]interface{}) func(string, primitive.M) map[string]interface{} {
+	return func(_ string, _ primitive.M) map[string]interface{} {
+		return value
+	}
+}
+
+func Test_handleDeviceGroupPost(t *testing.T) {
+	var deviceGroups = []configmodels.DeviceGroups{deviceGroup("group1"), deviceGroup("group2"), deviceGroup("group_no_imsis"), deviceGroup("group_no_traf_class"), deviceGroup("group_no_qos"), configmodels.DeviceGroups{}}
+	deviceGroups[2].Imsis = []string{}
+	deviceGroups[3].IpDomainExpanded.UeDnnQos.TrafficClass = nil
+	deviceGroups[4].IpDomainExpanded.UeDnnQos = nil
+	factory.WebUIConfig.Configuration.Mode5G = true
+
+	for _, testGroup := range deviceGroups {
+		configMsg := configmodels.ConfigMessage{
+			DevGroupName: testGroup.DeviceGroupName,
+			DevGroup:     &testGroup,
+		}
+		subsUpdateChan := make(chan *Update5GSubscriberMsg, 10)
+		postData = make([]map[string]interface{}, 0)
+		RestfulAPIPost = fakeMongoPost
+		RestfulAPIGetOne = fakeMongoGetOne(nil)
+
+		handleDeviceGroupPost(&configMsg, subsUpdateChan)
+
+		expected_collection := "webconsoleData.snapshots.devGroupData"
+		if postData[0]["coll"] != expected_collection {
+			t.Errorf("Expected collection %v, got %v", expected_collection, postData[0]["coll"])
+		}
+		expected_filter := bson.M{"DeviceGroupName": testGroup.DeviceGroupName}
+		if !reflect.DeepEqual(postData[0]["filter"], expected_filter) {
+			t.Errorf("Expected filter %v, got %v", expected_filter, postData[0]["filter"])
+		}
+		var resultGroup configmodels.DeviceGroups
+		var result map[string]interface{} = postData[0]["data"].(map[string]interface{})
+		json.Unmarshal(mapToByte(result), &resultGroup)
+		if !reflect.DeepEqual(resultGroup, testGroup) {
+			t.Errorf("Expected group %v, got %v", testGroup, resultGroup)
+		}
+		receivedConfigMsg, _ := <-subsUpdateChan
+		if !reflect.DeepEqual(receivedConfigMsg.Msg, &configMsg) {
+			t.Errorf("Expected config message %v, got %v", configMsg, receivedConfigMsg.Msg)
+		}
+		if receivedConfigMsg.PrevDevGroup.DeviceGroupName != "" {
+			t.Errorf("Expected previous device group name to be empty, got %v", receivedConfigMsg.PrevDevGroup.DeviceGroupName)
+		}
+	}
+}
+
+func Test_handleDeviceGroupPost_alreadyExists(t *testing.T) {
+	var deviceGroups = []configmodels.DeviceGroups{deviceGroup("group1"), deviceGroup("group2"), deviceGroup("group_no_imsis"), deviceGroup("group_no_traf_class"), deviceGroup("group_no_qos"), configmodels.DeviceGroups{}}
+	deviceGroups[2].Imsis = []string{}
+	deviceGroups[3].IpDomainExpanded.UeDnnQos.TrafficClass = nil
+	deviceGroups[4].IpDomainExpanded.UeDnnQos = nil
+	factory.WebUIConfig.Configuration.Mode5G = true
+
+	for _, testGroup := range deviceGroups {
+		configMsg := configmodels.ConfigMessage{
+			DevGroupName: testGroup.DeviceGroupName,
+			DevGroup:     &testGroup,
+		}
+		subsUpdateChan := make(chan *Update5GSubscriberMsg, 10)
+		postData = make([]map[string]interface{}, 0)
+		var previousGroupBson bson.M
+		previousGroup, _ := json.Marshal(testGroup)
+		json.Unmarshal(previousGroup, &previousGroupBson)
+		RestfulAPIPost = fakeMongoPost
+		RestfulAPIGetOne = fakeMongoGetOne(previousGroupBson)
+
+		handleDeviceGroupPost(&configMsg, subsUpdateChan)
+
+		expected_collection := "webconsoleData.snapshots.devGroupData"
+		if postData[0]["coll"] != expected_collection {
+			t.Errorf("Expected collection %v, got %v", expected_collection, postData[0]["coll"])
+		}
+		expected_filter := bson.M{"DeviceGroupName": testGroup.DeviceGroupName}
+		if !reflect.DeepEqual(postData[0]["filter"], expected_filter) {
+			t.Errorf("Expected filter %v, got %v", expected_filter, postData[0]["filter"])
+		}
+		var resultGroup configmodels.DeviceGroups
+		var result map[string]interface{} = postData[0]["data"].(map[string]interface{})
+		json.Unmarshal(mapToByte(result), &resultGroup)
+		if !reflect.DeepEqual(resultGroup, testGroup) {
+			t.Errorf("Expected group %v, got %v", testGroup, resultGroup)
+		}
+		receivedConfigMsg, _ := <-subsUpdateChan
+		if !reflect.DeepEqual(receivedConfigMsg.Msg, &configMsg) {
+			t.Errorf("Expected config message %v, got %v", configMsg, receivedConfigMsg.Msg)
+		}
+		if !reflect.DeepEqual(receivedConfigMsg.PrevDevGroup, &testGroup) {
+			t.Errorf("Expected previous device group to be %v, got %v", testGroup, receivedConfigMsg.PrevDevGroup)
+		}
+	}
+}
+
+func networkSlice(name string) configmodels.Slice {
+	upf := make(map[string]interface{}, 0)
+	upf["upf-name"] = "upf"
+	upf["upf-port"] = "8805"
+	plmn := configmodels.SliceSiteInfoPlmn{
+		Mcc: "208",
+		Mnc: "93",
+	}
+	gnodeb := configmodels.SliceSiteInfoGNodeBs{
+		Name: "demo-gnb1",
+		Tac:  1,
+	}
+	slice_id := configmodels.SliceSliceId{
+		Sst: "1",
+		Sd:  "010203",
+	}
+	site_info := configmodels.SliceSiteInfo{
+		SiteName: "demo",
+		Plmn:     plmn,
+		GNodeBs:  []configmodels.SliceSiteInfoGNodeBs{gnodeb},
+		Upf:      upf,
+	}
+	slice := configmodels.Slice{
+		SliceName:       name,
+		SliceId:         slice_id,
+		SiteDeviceGroup: []string{"group1", "group2"},
+		SiteInfo:        site_info,
+	}
+	return slice
+}
+
+func Test_handleNetworkSlicePost(t *testing.T) {
+	var networkSlices = []configmodels.Slice{networkSlice("slice1"), networkSlice("slice2"), networkSlice("slice_no_gnodeb"), networkSlice("slice_no_device_groups"), configmodels.Slice{}}
+	networkSlices[2].SiteInfo.GNodeBs = []configmodels.SliceSiteInfoGNodeBs{}
+	networkSlices[3].SiteDeviceGroup = []string{}
+	factory.WebUIConfig.Configuration.Mode5G = true
+
+	for _, testSlice := range networkSlices {
+		configMsg := configmodels.ConfigMessage{
+			SliceName: testSlice.SliceName,
+			Slice:     &testSlice,
+		}
+		subsUpdateChan := make(chan *Update5GSubscriberMsg, 10)
+		postData = make([]map[string]interface{}, 0)
+		RestfulAPIPost = fakeMongoPost
+		RestfulAPIGetOne = fakeMongoGetOne(nil)
+
+		handleNetworkSlicePost(&configMsg, subsUpdateChan)
+
+		expected_collection := "webconsoleData.snapshots.sliceData"
+		if postData[0]["coll"] != expected_collection {
+			t.Errorf("Expected collection %v, got %v", expected_collection, postData[0]["coll"])
+		}
+		expected_filter := bson.M{"SliceName": testSlice.SliceName}
+		if !reflect.DeepEqual(postData[0]["filter"], expected_filter) {
+			t.Errorf("Expected filter %v, got %v", expected_filter, postData[0]["filter"])
+		}
+		var resultSlice configmodels.Slice
+		var result map[string]interface{} = postData[0]["data"].(map[string]interface{})
+		json.Unmarshal(mapToByte(result), &resultSlice)
+		if !reflect.DeepEqual(resultSlice, testSlice) {
+			t.Errorf("Expected slice %v, got %v", testSlice, resultSlice)
+		}
+		receivedConfigMsg, _ := <-subsUpdateChan
+		if !reflect.DeepEqual(receivedConfigMsg.Msg, &configMsg) {
+			t.Errorf("Expected config message %v, got %v", configMsg, receivedConfigMsg.Msg)
+		}
+		if receivedConfigMsg.PrevSlice.SliceName != "" {
+			t.Errorf("Expected previous network slice name to be empty, got %v", receivedConfigMsg.PrevSlice.SliceName)
+		}
+	}
+}
+
+func Test_handleNetworkSlicePost_alreadyExists(t *testing.T) {
+	var networkSlices = []configmodels.Slice{networkSlice("slice1"), networkSlice("slice2"), networkSlice("slice_no_gnodeb"), networkSlice("slice_no_device_groups"), configmodels.Slice{}}
+	networkSlices[2].SiteInfo.GNodeBs = []configmodels.SliceSiteInfoGNodeBs{}
+	networkSlices[3].SiteDeviceGroup = []string{}
+	factory.WebUIConfig.Configuration.Mode5G = true
+
+	for _, testSlice := range networkSlices {
+		configMsg := configmodels.ConfigMessage{
+			SliceName: testSlice.SliceName,
+			Slice:     &testSlice,
+		}
+		subsUpdateChan := make(chan *Update5GSubscriberMsg, 10)
+		postData = make([]map[string]interface{}, 0)
+		var previousSliceBson bson.M
+		previousSlice, _ := json.Marshal(testSlice)
+		json.Unmarshal(previousSlice, &previousSliceBson)
+		RestfulAPIPost = fakeMongoPost
+		RestfulAPIGetOne = fakeMongoGetOne(previousSliceBson)
+
+		handleNetworkSlicePost(&configMsg, subsUpdateChan)
+
+		expected_collection := "webconsoleData.snapshots.sliceData"
+		if postData[0]["coll"] != expected_collection {
+			t.Errorf("Expected collection %v, got %v", expected_collection, postData[0]["coll"])
+		}
+		expected_filter := bson.M{"SliceName": testSlice.SliceName}
+		if !reflect.DeepEqual(postData[0]["filter"], expected_filter) {
+			t.Errorf("Expected filter %v, got %v", expected_filter, postData[0]["filter"])
+		}
+		var resultSlice configmodels.Slice
+		var result map[string]interface{} = postData[0]["data"].(map[string]interface{})
+		json.Unmarshal(mapToByte(result), &resultSlice)
+		if !reflect.DeepEqual(resultSlice, testSlice) {
+			t.Errorf("Expected slice %v, got %v", testSlice, resultSlice)
+		}
+		receivedConfigMsg, _ := <-subsUpdateChan
+		if !reflect.DeepEqual(receivedConfigMsg.Msg, &configMsg) {
+			t.Errorf("Expected config message %v, got %v", configMsg, receivedConfigMsg.Msg)
+		}
+		if !reflect.DeepEqual(receivedConfigMsg.PrevSlice, &testSlice) {
+			t.Errorf("Expected previous network slice to be %v, got %v", testSlice, receivedConfigMsg.PrevSlice)
+		}
+	}
+}

--- a/proto/server/configEvtHandler_test.go
+++ b/proto/server/configEvtHandler_test.go
@@ -89,7 +89,7 @@ func Test_handleDeviceGroupPost(t *testing.T) {
 		if postData[0]["coll"] != expected_collection {
 			t.Errorf("Expected collection %v, got %v", expected_collection, postData[0]["coll"])
 		}
-		expected_filter := bson.M{"DeviceGroupName": testGroup.DeviceGroupName}
+		expected_filter := bson.M{"group-name": testGroup.DeviceGroupName}
 		if !reflect.DeepEqual(postData[0]["filter"], expected_filter) {
 			t.Errorf("Expected filter %v, got %v", expected_filter, postData[0]["filter"])
 		}
@@ -135,7 +135,7 @@ func Test_handleDeviceGroupPost_alreadyExists(t *testing.T) {
 		if postData[0]["coll"] != expected_collection {
 			t.Errorf("Expected collection %v, got %v", expected_collection, postData[0]["coll"])
 		}
-		expected_filter := bson.M{"DeviceGroupName": testGroup.DeviceGroupName}
+		expected_filter := bson.M{"group-name": testGroup.DeviceGroupName}
 		if !reflect.DeepEqual(postData[0]["filter"], expected_filter) {
 			t.Errorf("Expected filter %v, got %v", expected_filter, postData[0]["filter"])
 		}

--- a/proto/server/gServer.go
+++ b/proto/server/gServer.go
@@ -124,7 +124,7 @@ func (c *ConfigServer) NetworkSliceSubscribe(req *protos.NetworkSliceRequest, st
 			delete(clientNFPool, req.ClientId)
 			return nil
 		case <-ctx.Done():
-			client.clientLog.Infof("Client ID %d has disconnected", req.ClientId)
+			client.clientLog.Infof("Client ID %s has disconnected", req.ClientId)
 			delete(clientNFPool, req.ClientId)
 			return nil
 		}


### PR DESCRIPTION
This PR goal is to introduce GET operations to the API for DeviceGroups and Network Slices. To do so, the following changes were needed:

1. Move the snapshots from in-memory maps to Mongo in new collections
2. Add GET operations for DeviceGroups and Slices, looking up in those new Mongo collections
3. Add some unit tests for the new code
4. Add test target to the Makefile
5. Add GitHub workflow to run the unit tests

The larger goal is to be able to create a simple web application to configure SD-Core without requiring a full Aether installation for simple use cases.