### PR TITLE
fix: Recover configuration from DB on restart

### DIFF
--- a/proto/server/configEvtHandler.go
+++ b/proto/server/configEvtHandler.go
@@ -207,12 +207,7 @@ func handleNetworkSlicePost(configMsg *configmodels.ConfigMessage, subsUpdateCha
 }
 
 func firstConfigReceived() bool {
-	if len(getDeviceGroups()) > 0 {
-		return true
-	} else if len(getSlices()) > 0 {
-		return true
-	}
-	return false
+	return len(getDeviceGroups()) > 0 || len(getSlices()) > 0
 }
 
 func getDeviceGroups() []*configmodels.DeviceGroups {

--- a/proto/server/configEvtHandler.go
+++ b/proto/server/configEvtHandler.go
@@ -76,7 +76,10 @@ func configHandler(configMsgChan chan *configmodels.ConfigMessage, configReceive
 	if factory.WebUIConfig.Configuration.Mode5G == true {
 		go Config5GUpdateHandle(subsUpdateChan)
 	}
-	firstConfigRcvd := false
+	firstConfigRcvd := firstConfigReceived()
+	if firstConfigRcvd {
+		configReceived <- true
+	}
 	for {
 		configLog.Infoln("Waiting for configuration event ")
 		select {
@@ -201,6 +204,15 @@ func handleNetworkSlicePost(configMsg *configmodels.ConfigMessage, subsUpdateCha
 	sliceDataBsonA := toBsonM(configMsg.Slice)
 	RestfulAPIPost(sliceDataColl, filter, sliceDataBsonA)
 	rwLock.Unlock()
+}
+
+func firstConfigReceived() bool {
+	if len(getDeviceGroups()) > 0 {
+		return true
+	} else if len(getSlices()) > 0 {
+		return true
+	}
+	return false
 }
 
 func getDeviceGroups() []*configmodels.DeviceGroups {


### PR DESCRIPTION
This change makes webconsole check its database on startup for existing network slices or device groups instead of waiting for new configuration to be POSTed.

This was tested with a full deployment of SD-Core, running a simulation with gnbsim. After a successful simulation, I took a backup of the database, removed the entire infrastructure, and redeployed mongo, restoring from the backup, then redeploying SD-Core and running a new successful simulation with gnbsim.

fixes #85 