### PR TITLE
chore: Adds dependabot.yaml config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 Canonical Ltd.
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Description

This PR adds a dependabot.yaml file so that Dependabot can come and propose library updates to the project through Pull Requests. This prevents having developers regularly looking up for library changes and avoids distributing code that should have been patched. Dependabot is also used in other SD-Core projects like the UPF and the config file here was taken from there.

For more information about dependabot:
- https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates
