### PR TITLE
chore: Uses go version from go.mod

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version-file: 'go.mod'
 
       - name: Build
         run: go build
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version-file: 'go.mod'
 
       - name: Unit tests
         run: go test ./...


### PR DESCRIPTION
# Description

Uses the go version from the go.mod file instead of freezing it to 1.21 in the CI.