### PR TITLE
Store authentication keys in a separate database

### DIFF
--- a/backend/factory/config.go
+++ b/backend/factory/config.go
@@ -46,8 +46,10 @@ type WebServer struct {
 }
 
 type Mongodb struct {
-	Name string `yaml:"name,omitempty"`
-	Url  string `yaml:"url,omitempty"`
+	Name           string `yaml:"name,omitempty"`
+	Url            string `yaml:"url,omitempty"`
+	AuthKeysDbName string `yaml:"authKeysDbName"`
+	AuthUrl        string `yaml:"authUrl"`
 }
 
 type RocEndpt struct {

--- a/backend/factory/factory.go
+++ b/backend/factory/factory.go
@@ -36,6 +36,13 @@ func InitConfigFactory(f string) error {
 		if yamlErr := yaml.Unmarshal(content, WebUIConfig); yamlErr != nil {
 			return fmt.Errorf("[Configuration] %+v", yamlErr)
 		}
+		if WebUIConfig.Configuration.Mongodb.AuthUrl == "" {
+			authUrl := WebUIConfig.Configuration.Mongodb.Url
+			WebUIConfig.Configuration.Mongodb.AuthUrl = authUrl
+		}
+		if WebUIConfig.Configuration.Mongodb.AuthKeysDbName == "" {
+			WebUIConfig.Configuration.Mongodb.AuthKeysDbName = "authentication"
+		}
 		// we dont want Mode5G coming from the helm chart, since
 		// there is chance of misconfiguration
 		if os.Getenv("CONFIGPOD_DEPLOYMENT") == "4G" {

--- a/backend/webui_service/webui_init.go
+++ b/backend/webui_service/webui_init.go
@@ -163,7 +163,7 @@ func (webui *WEBUI) Start() {
 		mongodb := factory.WebUIConfig.Configuration.Mongodb
 
 		// Connect to MongoDB
-		dbadapter.ConnectMongo(mongodb.Url, mongodb.Name)
+		dbadapter.ConnectMongo(mongodb.Url, mongodb.Name, mongodb.AuthUrl, mongodb.AuthKeysDbName)
 	}
 
 	initLog.Infoln("WebUI Server started")

--- a/configapi/api_sub_config.go
+++ b/configapi/api_sub_config.go
@@ -307,7 +307,7 @@ func GetSubscriberByID(c *gin.Context) {
 
 	filterUeIdOnly := bson.M{"ueId": ueId}
 
-	authSubsDataInterface, errGetOneAuth := dbadapter.CommonDBClient.RestfulAPIGetOne(authSubsDataColl, filterUeIdOnly)
+	authSubsDataInterface, errGetOneAuth := dbadapter.AuthDBClient.RestfulAPIGetOne(authSubsDataColl, filterUeIdOnly)
 	if errGetOneAuth != nil {
 		logger.DbLog.Warnln(errGetOneAuth)
 	}

--- a/proto/server/configEvtHandler.go
+++ b/proto/server/configEvtHandler.go
@@ -490,14 +490,14 @@ func Config5GUpdateHandle(confChan chan *Update5GSubscriberMsg) {
 				filter := bson.M{"ueId": confData.Msg.Imsi}
 				authDataBsonA := toBsonM(confData.Msg.AuthSubData)
 				authDataBsonA["ueId"] = confData.Msg.Imsi
-				_, errPost := dbadapter.CommonDBClient.RestfulAPIPost(authSubsDataColl, filter, authDataBsonA)
+				_, errPost := dbadapter.AuthDBClient.RestfulAPIPost(authSubsDataColl, filter, authDataBsonA)
 				if errPost != nil {
 					logger.DbLog.Warnln(errPost)
 				}
 			} else {
 				logger.WebUILog.Debugln("Delete AuthenticationSubscription", imsi)
 				filter := bson.M{"ueId": "imsi-" + imsi}
-				errDelOne := dbadapter.CommonDBClient.RestfulAPIDeleteOne(authSubsDataColl, filter)
+				errDelOne := dbadapter.AuthDBClient.RestfulAPIDeleteOne(authSubsDataColl, filter)
 				if errDelOne != nil {
 					logger.DbLog.Warnln(errDelOne)
 				}


### PR DESCRIPTION
Storing authentication keys in a separate database by using separate MongoDB clients.
Aiming to fix https://github.com/omec-project/webconsole/issues/112.