### PR TITLE
feat: add static files support for ui

### DIFF
--- a/backend/webui_service/serve_static_files.go
+++ b/backend/webui_service/serve_static_files.go
@@ -1,0 +1,8 @@
+//go:build !ui
+// +build !ui
+
+package webui_service
+
+import "github.com/gin-gonic/gin"
+
+func (*WEBUI) SetUpStaticFiles(router *gin.Engine) {}

--- a/backend/webui_service/serve_static_files.go
+++ b/backend/webui_service/serve_static_files.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 4 Canonical Ltd.
+
 //go:build !ui
 // +build !ui
 

--- a/backend/webui_service/serve_static_files_with_frontend.go
+++ b/backend/webui_service/serve_static_files_with_frontend.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Canonical Ltd.
+
 //go:build ui
 // +build ui
 

--- a/backend/webui_service/serve_static_files_with_frontend.go
+++ b/backend/webui_service/serve_static_files_with_frontend.go
@@ -1,0 +1,18 @@
+//go:build ui
+// +build ui
+
+package webui_service
+
+import (
+	"embed"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+//go:embed webui/frontend/dist/*
+var staticFiles embed.FS
+
+func (*WEBUI) SetUpStaticFiles(router *gin.Engine) {
+	router.StaticFS("/static", http.FS(staticFiles))
+}

--- a/backend/webui_service/webui_init.go
+++ b/backend/webui_service/webui_init.go
@@ -10,12 +10,13 @@ package webui_service
 import (
 	"bufio"
 	"fmt"
-	"github.com/omec-project/webconsole/dbadapter"
 	"net/http"
 	"os/exec"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/omec-project/webconsole/dbadapter"
 
 	"github.com/gin-contrib/cors"
 	"github.com/omec-project/http2_util"
@@ -187,7 +188,7 @@ func (webui *WEBUI) Start() {
 		AllowAllOrigins:  true,
 		MaxAge:           86400,
 	}))
-
+	webui.SetUpStaticFiles(subconfig_router)
 	go func() {
 		httpAddr := ":" + strconv.Itoa(factory.WebUIConfig.Configuration.CfgPort)
 		initLog.Infoln("Webui HTTP addr:", httpAddr, factory.WebUIConfig.Configuration.CfgPort)


### PR DESCRIPTION
# Description

This PR adds support for serving static files making it possible to have a UI in front of webui. This feature is enabled via go build tags, making no changes to the default behavior.

## Usage

- Build the UI
- Copy the static files over to the appropriate directory
- Build webconsole with the `ui` build tag
- Run it

## Rationale

Canonical builds its own UI for WebConsole (we call it [NMS](https://github.com/canonical/sdcore-nms)), which is currently operated as a standalone service. The goal is for us to be able to build and deploy WebConsole as one service/container, including both the backend and front end.

## WIP

This is still a work in progress, it needs to be properly tested.