### PR TITLE
Enable `signoff` in GHA

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -168,7 +168,7 @@ jobs:
           commit-message: Update version
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
-          signoff: false
+          signoff: true
           branch: version-update
           delete-branch: true
           title: Update version


### PR DESCRIPTION
This change is required to due to the enabling of the `DCO` action.