### PR TITLE
fix: improve regex used for name and FQDN validation

### DIFF
--- a/configapi/api_inventory_test.go
+++ b/configapi/api_inventory_test.go
@@ -279,7 +279,7 @@ func TestGnbPostHandler(t *testing.T) {
 			dbAdapter:    &MockMongoClientEmptyDB{},
 			inputData:    `{"tac": "12"}`,
 			expectedCode: http.StatusBadRequest,
-			expectedBody: `{"error":"invalid gNB name ''. Name needs to match the following regular expression: ^[a-zA-Z0-9-_]+$"}`,
+			expectedBody: `{"error":"invalid gNB name ''. Name needs to match the following regular expression: ^[a-zA-Z][a-zA-Z0-9-_]+$"}`,
 		},
 		{
 			name:         "Invalid gNB name expects failure",
@@ -287,7 +287,7 @@ func TestGnbPostHandler(t *testing.T) {
 			dbAdapter:    &MockMongoClientEmptyDB{},
 			inputData:    `{"name": "gn!b1", "tac": "123"}`,
 			expectedCode: http.StatusBadRequest,
-			expectedBody: `{"error":"invalid gNB name 'gn!b1'. Name needs to match the following regular expression: ^[a-zA-Z0-9-_]+$"}`,
+			expectedBody: `{"error":"invalid gNB name 'gn!b1'. Name needs to match the following regular expression: ^[a-zA-Z][a-zA-Z0-9-_]+$"}`,
 		},
 	}
 	for _, tc := range testCases {
@@ -378,7 +378,7 @@ func TestGnbPutHandler(t *testing.T) {
 			dbAdapter:    &MockMongoClientEmptyDB{},
 			inputData:    `{"tac": "123"}`,
 			expectedCode: http.StatusBadRequest,
-			expectedBody: `{"error":"invalid gNB name 'gn!b1'. Name needs to match the following regular expression: ^[a-zA-Z0-9-_]+$"}`,
+			expectedBody: `{"error":"invalid gNB name 'gn!b1'. Name needs to match the following regular expression: ^[a-zA-Z][a-zA-Z0-9-_]+$"}`,
 		},
 	}
 	for _, tc := range testCases {

--- a/configapi/validators.go
+++ b/configapi/validators.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 )
 
-const NAME_PATTERN = "^[a-zA-Z0-9-_]+$"
-const FQDN_PATTERN = "^([a-zA-Z0-9-]+\\.){2,}([a-zA-Z]{2,6})$"
+const NAME_PATTERN = "^[a-zA-Z][a-zA-Z0-9-_]+$"
+const FQDN_PATTERN = "^([a-zA-Z0-9][a-zA-Z0-9-]+\\.){2,}([a-zA-Z]{2,6})$"
 
 func isValidName(name string) bool {
 	nameMatch, err := regexp.MatchString(NAME_PATTERN, name)

--- a/configapi/validators_test.go
+++ b/configapi/validators_test.go
@@ -10,12 +10,17 @@ func TestValidateName(t *testing.T) {
 		name     string
 		expected bool
 	}{
-		{"validName", true},
+
 		{"Valid-Name", true},
 		{"Valid_Name", true},
 		{"{invalid_name}", false},
 		{"invalid&name", false},
 		{"invalidName(R)", false},
+		{"-invalidName", false},
+		{"_invalidName", false},
+		{"4invalidName", false},
+		{"-_invalid", false},
+		{"-_invalid", false},
 		{"", false},
 	}
 
@@ -33,6 +38,7 @@ func TestValidateFQDN(t *testing.T) {
 		expected bool
 	}{
 		{"upf-external.sdcore.svc.cluster.local", true},
+		{"123-external.sdcore.svc.cluster.local", true},
 		{"my-upf.my-domain.com", true},
 		{"www.my-upf.com", true},
 		{"some-upf-name", false},
@@ -40,6 +46,7 @@ func TestValidateFQDN(t *testing.T) {
 		{"{upf-external}.sdcore.svc.cluster.local", false},
 		{"http://my-upf.my-domain.com", false},
 		{"my-domain.com/my-upf", false},
+		{"-upf-external.sdcore.svc.cluster.local", false},
 		{"", false},
 	}
 

--- a/configapi/validators_test.go
+++ b/configapi/validators_test.go
@@ -10,7 +10,7 @@ func TestValidateName(t *testing.T) {
 		name     string
 		expected bool
 	}{
-
+		{"validName", true},
 		{"Valid-Name", true},
 		{"Valid_Name", true},
 		{"{invalid_name}", false},
@@ -19,7 +19,6 @@ func TestValidateName(t *testing.T) {
 		{"-invalidName", false},
 		{"_invalidName", false},
 		{"4invalidName", false},
-		{"-_invalid", false},
 		{"-_invalid", false},
 		{"", false},
 	}


### PR DESCRIPTION
This PR improve the regex used for name validation and FQDN validate:

1. Names only starts with letters
2. FQDN can start with letters or numbers but not `-`