### PR TITLE
feat: return 409 conflict error if a subscriber already exists

### DIFF
--- a/configapi/api_sub_config.go
+++ b/configapi/api_sub_config.go
@@ -446,6 +446,7 @@ func GetSubscriberByID(c *gin.Context) {
 // @Failure      400  {object}  nil  "Invalid subscriber content"
 // @Failure      401  {object}  nil  "Authorization failed"
 // @Failure      403  {object}  nil  "Forbidden"
+// @Failure      409  {object}  nil  "Subscriber already exists"
 // @Failure      500  {object}  nil  "Error creating subscriber"
 // @Router      /api/subscriber/{imsi}  [post]
 func PostSubscriberByID(c *gin.Context) {
@@ -466,12 +467,12 @@ func PostSubscriberByID(c *gin.Context) {
 	filter := bson.M{"ueId": ueId}
 	subscriber, err := dbadapter.CommonDBClient.RestfulAPIGetOne(amDataColl, filter)
 	if err != nil {
-		logger.DbLog.Errorw("failed to check subscriber existence", "IMSI", ueId, "error", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to check subscriber existence: %v", err)})
+		logger.DbLog.Errorf("Failed querying subscriber existence for IMSI: %s; Error: %v", ueId, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to check subscriber: %s existence", ueId)})
 		return
 	} else if subscriber != nil {
-		logger.WebUILog.Errorf("subscriber with IMSI %s already exists", ueId)
-		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("subscriber with IMSI %s already exists", ueId)})
+		logger.WebUILog.Errorf("subscriber %s already exists", ueId)
+		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("subscriber %s already exists", ueId)})
 		return
 	}
 	authSubsData := models.AuthenticationSubscription{

--- a/configapi/api_sub_config.go
+++ b/configapi/api_sub_config.go
@@ -467,7 +467,7 @@ func PostSubscriberByID(c *gin.Context) {
 	filter := bson.M{"ueId": ueId}
 	subscriber, err := dbadapter.CommonDBClient.RestfulAPIGetOne(amDataColl, filter)
 	if err != nil {
-		logger.DbLog.Errorf("Failed querying subscriber existence for IMSI: %s; Error: %v", ueId, err)
+		logger.DbLog.Errorf("failed querying subscriber existence for IMSI: %s; Error: %v", ueId, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to check subscriber: %s existence", ueId)})
 		return
 	} else if subscriber != nil {

--- a/configapi/api_sub_config.go
+++ b/configapi/api_sub_config.go
@@ -523,7 +523,20 @@ func PostSubscriberByID(c *gin.Context) {
 	logger.WebUILog.Infoln("Successfully Added Subscriber Data to ConfigChannel: ", ueId)
 }
 
-// Put subscriber by IMSI(ueId) and PlmnID(servingPlmnId)
+// PutSubscriberByID godoc
+//
+// @Description  Update subscriber information by IMSI (UE ID)
+// @Tags         Subscribers
+// @Param        imsi       path    string                           true    "IMSI (UE ID)"
+// @Param        content    body    configmodels.SubsData            true    "Updated subscriber details"
+// @Security     BearerAuth
+// @Success      204  {object}  nil  "Subscriber updated successfully"
+// @Failure      400  {object}  nil  "Invalid subscriber content"
+// @Failure      401  {object}  nil  "Authorization failed"
+// @Failure      403  {object}  nil  "Forbidden"
+// @Failure      404  {object}  nil  "Subscriber not found"
+// @Failure      500  {object}  nil  "Error updating subscriber"
+// @Router       /api/subscriber/{imsi}  [put]
 func PutSubscriberByID(c *gin.Context) {
 	setCorsHeader(c)
 	logger.WebUILog.Infoln("Put One Subscriber Data")

--- a/configapi/api_sub_config_test.go
+++ b/configapi/api_sub_config_test.go
@@ -728,16 +728,17 @@ func TestSubscriberPostHandlersSubscriberAlreadyExists(t *testing.T) {
 				t.Errorf("Expected `%v`, got `%v`", expectedBody, w.Body.String())
 			}
 			// Validate channel behavior
+
 			if tc.expectedMessage == nil {
 				select {
-				case _ = <-configChannel:
+				case <-configChannel:
 					t.Error("expected no message in configChannel, but got one")
 				default:
 					// No message received, as expected
 				}
 			} else {
 				select {
-				case _ = <-configChannel:
+				case <-configChannel:
 				default:
 					t.Error("expected message in configChannel, but none received")
 				}

--- a/configapi/api_sub_config_test.go
+++ b/configapi/api_sub_config_test.go
@@ -594,7 +594,7 @@ func TestSubscriberGetHandlers(t *testing.T) {
 	}
 }
 
-func TestSubscriberPostHandlersNoSubscriber(t *testing.T) {
+func TestSubscriberPostHandlersNoExistingSubscriber(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
 	AddApiService(router)

--- a/configapi/api_sub_config_test.go
+++ b/configapi/api_sub_config_test.go
@@ -4,13 +4,13 @@
 package configapi
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -22,6 +22,7 @@ import (
 
 type MockMongoClientOneSubscriber struct {
 	dbadapter.DBInterface
+	PostDataCommon *[]map[string]interface{}
 }
 
 type MockMongoClientManySubscribers struct {
@@ -46,6 +47,13 @@ func (m *MockMongoClientOneSubscriber) RestfulAPIGetMany(coll string, filter bso
 }
 
 func (m *MockMongoClientOneSubscriber) RestfulAPIGetOne(collName string, filter bson.M) (map[string]interface{}, error) {
+	if m.PostDataCommon != nil {
+		*m.PostDataCommon = append(*m.PostDataCommon, map[string]interface{}{
+			"coll":   collName,
+			"filter": filter,
+		})
+	}
+
 	subscriber := configmodels.ToBsonM(models.AccessAndMobilitySubscriptionData{})
 	subscriber["ueId"] = "208930100007487"
 	subscriber["servingPlmnId"] = "12345"
@@ -586,164 +594,164 @@ func TestSubscriberGetHandlers(t *testing.T) {
 	}
 }
 
-func TestSubscriberPostHandlers(t *testing.T) {
+func TestSubscriberPostHandlersNoSubscriber(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
 	AddApiService(router)
 
-	testCases := []struct {
-		name            string
-		route           string
-		inputData       string
-		expectedCode    int
-		expectedBody    string
-		expectedMessage *configmodels.ConfigMessage
-	}{
-		{
-			name:         "Create a new subscriber success",
-			route:        "/api/subscriber/imsi-208930100007487",
-			inputData:    `{"plmnID":"12345", "opc":"8e27b6af0e692e750f32667a3b14605d","key":"8baf473f2f8fd09487cccbd7097c6862", "sequenceNumber":"16f3b3f70fc2"}`,
-			expectedCode: http.StatusCreated,
-			expectedBody: `{"imsi":"imsi-208930100007487"}`,
-			expectedMessage: &configmodels.ConfigMessage{
-				MsgType:   configmodels.Sub_data,
-				MsgMethod: configmodels.Post_op,
-				AuthSubData: &models.AuthenticationSubscription{
-					AuthenticationManagementField: "8000",
-					AuthenticationMethod:          "5G_AKA",
-					Milenage: &models.Milenage{
-						Op: &models.Op{
-							EncryptionAlgorithm: 0,
-							EncryptionKey:       0,
-						},
-					},
-					Opc: &models.Opc{
-						EncryptionAlgorithm: 0,
-						EncryptionKey:       0,
-						OpcValue:            "8e27b6af0e692e750f32667a3b14605d",
-					},
-					PermanentKey: &models.PermanentKey{
-						EncryptionAlgorithm: 0,
-						EncryptionKey:       0,
-						PermanentKeyValue:   "8baf473f2f8fd09487cccbd7097c6862",
-					},
-					SequenceNumber: "16f3b3f70fc2",
-				},
-				Imsi: "imsi-208930100007487",
-			},
-		},
+	postDataCommon := make([]map[string]interface{}, 0)
+	route := "/api/subscriber/imsi-208930100007487"
+	inputData := map[string]string{
+		"plmnID":         "12345",
+		"opc":            "8e27b6af0e692e750f32667a3b14605d",
+		"key":            "8baf473f2f8fd09487cccbd7097c6862",
+		"sequenceNumber": "16f3b3f70fc2",
 	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			origDBClient := dbadapter.CommonDBClient
-			dbadapter.CommonDBClient = &MockMongoClientNoSubscriberInDB{}
-			origChannel := configChannel
-			configChannel = make(chan *configmodels.ConfigMessage, 1)
-			defer func() { configChannel = origChannel; dbadapter.CommonDBClient = origDBClient }()
-			req, err := http.NewRequest(http.MethodPost, tc.route, strings.NewReader(tc.inputData))
-			if err != nil {
-				t.Fatalf("failed to create request: %v", err)
-			}
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
 
-			router.ServeHTTP(w, req)
+	jsonData, err := json.Marshal(inputData)
+	if err != nil {
+		t.Fatalf("failed to marshal input data to JSON: %v", err)
+	}
 
-			expectedCode := http.StatusCreated
-			expectedBody := "{}"
+	commonDbAdapter := &MockMongoClientNoSubscriberInDB{PostDataCommon: &postDataCommon}
+	origDBClient := dbadapter.CommonDBClient
+	origChannel := configChannel
+	configChannel = make(chan *configmodels.ConfigMessage, 1)
+	defer func() { configChannel = origChannel; dbadapter.CommonDBClient = origDBClient }()
+	dbadapter.CommonDBClient = commonDbAdapter
 
-			if expectedCode != w.Code {
-				t.Errorf("Expected `%v`, got `%v`", expectedCode, w.Code)
-			}
-			if w.Body.String() != expectedBody {
-				t.Errorf("Expected `%v`, got `%v`", expectedBody, w.Body.String())
-			}
-			select {
-			case msg := <-configChannel:
+	expectedCode := http.StatusCreated
+	expectedBody := `{}`
+	expectedCommonPostDataDetails := []map[string]interface{}{
+		{"coll": "subscriptionData.provisionedData.amData", "filter": map[string]interface{}{"ueId": "imsi-208930100007487"}},
+	}
+	expectedMessage := &configmodels.ConfigMessage{
+		MsgType:   configmodels.Sub_data,
+		MsgMethod: configmodels.Post_op,
+		AuthSubData: &models.AuthenticationSubscription{
+			AuthenticationManagementField: "8000",
+			AuthenticationMethod:          "5G_AKA",
+			Milenage: &models.Milenage{
+				Op: &models.Op{
+					EncryptionAlgorithm: 0,
+					EncryptionKey:       0,
+				},
+			},
+			Opc: &models.Opc{
+				EncryptionAlgorithm: 0,
+				EncryptionKey:       0,
+				OpcValue:            "8e27b6af0e692e750f32667a3b14605d",
+			},
+			PermanentKey: &models.PermanentKey{
+				EncryptionAlgorithm: 0,
+				EncryptionKey:       0,
+				PermanentKeyValue:   "8baf473f2f8fd09487cccbd7097c6862",
+			},
+			SequenceNumber: "16f3b3f70fc2",
+		},
+		Imsi: "imsi-208930100007487",
+	}
 
-				if msg.MsgType != tc.expectedMessage.MsgType {
-					t.Errorf("expected MsgType %+v, but got %+v", tc.expectedMessage.MsgType, msg.MsgType)
-				}
-				if msg.MsgMethod != tc.expectedMessage.MsgMethod {
-					t.Errorf("expected MsgMethod %+v, but got %+v", tc.expectedMessage.MsgMethod, msg.MsgMethod)
-				}
-				if !reflect.DeepEqual(tc.expectedMessage.AuthSubData, msg.AuthSubData) {
-					t.Errorf("expected AuthSubData %+v, but got %+v", tc.expectedMessage.AuthSubData, msg.AuthSubData)
-				}
-				if tc.expectedMessage.Imsi != msg.Imsi {
-					t.Errorf("expected IMSI %+v, but got %+v", tc.expectedMessage.Imsi, msg.Imsi)
-				}
-			default:
-				t.Error("expected message in configChannel, but none received")
-			}
-		})
+	req, err := http.NewRequest(http.MethodPost, route, bytes.NewBuffer(jsonData))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != expectedCode {
+		t.Errorf("Expected `%v`, got `%v`", expectedCode, w.Code)
+	}
+	if w.Body.String() != expectedBody {
+		t.Errorf("Expected `%v`, got `%v`", expectedBody, w.Body.String())
+	}
+
+	expectedCommonData, _ := json.Marshal(expectedCommonPostDataDetails)
+	gotCommonData, _ := json.Marshal(postDataCommon)
+
+	if !reflect.DeepEqual(expectedCommonData, gotCommonData) {
+		t.Errorf("Expected CommonPostData `%v`, but got `%v`", expectedCommonPostDataDetails, postDataCommon)
+	}
+
+	select {
+	case msg := <-configChannel:
+		if msg.MsgType != expectedMessage.MsgType {
+			t.Errorf("expected MsgType %+v, but got %+v", expectedMessage.MsgType, msg.MsgType)
+		}
+		if msg.MsgMethod != expectedMessage.MsgMethod {
+			t.Errorf("expected MsgMethod %+v, but got %+v", expectedMessage.MsgMethod, msg.MsgMethod)
+		}
+		if !reflect.DeepEqual(expectedMessage.AuthSubData, msg.AuthSubData) {
+			t.Errorf("expected AuthSubData %+v, but got %+v", expectedMessage.AuthSubData, msg.AuthSubData)
+		}
+		if expectedMessage.Imsi != msg.Imsi {
+			t.Errorf("expected IMSI %+v, but got %+v", expectedMessage.Imsi, msg.Imsi)
+		}
+	default:
+		t.Error("expected message in configChannel, but none received")
 	}
 }
 
-func TestSubscriberPostHandlersSubscriberAlreadyExists(t *testing.T) {
+func TestSubscriberPostHandlersSubscriberExists(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
 	AddApiService(router)
 
-	testCases := []struct {
-		name            string
-		route           string
-		inputData       string
-		expectedCode    int
-		expectedBody    string
-		expectedMessage *configmodels.ConfigMessage
-	}{
-		{
-			name:            "Create subscriber conflict subscriber already exists",
-			route:           "/api/subscriber/imsi-208930100007487",
-			inputData:       `{"plmnID":"12345", "opc":"8e27b6af0e692e750f32667a3b14605d", "key":"8baf473f2f8fd09487cccbd7097c6862", "sequenceNumber":"16f3b3f70fc2"}`,
-			expectedCode:    http.StatusConflict,
-			expectedBody:    `{"error":"subscriber already exists"}`,
-			expectedMessage: nil,
-		},
+	postDataCommon := make([]map[string]interface{}, 0)
+	route := "/api/subscriber/imsi-208930100007487"
+	inputData := map[string]string{
+		"plmnID":         "12345",
+		"opc":            "8e27b6af0e692e750f32667a3b14605d",
+		"key":            "8baf473f2f8fd09487cccbd7097c6862",
+		"sequenceNumber": "16f3b3f70fc2",
 	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			origDBClient := dbadapter.CommonDBClient
-			dbadapter.CommonDBClient = &MockMongoClientOneSubscriber{}
-			origChannel := configChannel
-			configChannel = make(chan *configmodels.ConfigMessage, 1)
-			defer func() { configChannel = origChannel; dbadapter.CommonDBClient = origDBClient }()
-			req, err := http.NewRequest(http.MethodPost, tc.route, strings.NewReader(tc.inputData))
-			if err != nil {
-				t.Fatalf("failed to create request: %v", err)
-			}
-			req.Header.Set("Content-Type", "application/json")
-			w := httptest.NewRecorder()
 
-			router.ServeHTTP(w, req)
+	jsonData, err := json.Marshal(inputData)
+	if err != nil {
+		t.Fatalf("failed to marshal input data to JSON: %v", err)
+	}
 
-			expectedCode := http.StatusConflict
-			expectedBody := "{\"error\":\"subscriber with IMSI imsi-208930100007487 already exists\"}"
+	commonDbAdapter := &MockMongoClientOneSubscriber{PostDataCommon: &postDataCommon}
+	origDBClient := dbadapter.CommonDBClient
+	origChannel := configChannel
+	configChannel = make(chan *configmodels.ConfigMessage, 1)
+	defer func() { configChannel = origChannel; dbadapter.CommonDBClient = origDBClient }()
+	dbadapter.CommonDBClient = commonDbAdapter
 
-			if expectedCode != w.Code {
-				t.Errorf("Expected `%v`, got `%v`", expectedCode, w.Code)
-			}
-			if w.Body.String() != expectedBody {
-				t.Errorf("Expected `%v`, got `%v`", expectedBody, w.Body.String())
-			}
-			// Validate channel behavior
+	expectedCode := http.StatusConflict
+	expectedBody := `{"error":"subscriber imsi-208930100007487 already exists"}`
+	expectedCommonPostDataDetails := []map[string]interface{}{
+		{"coll": "subscriptionData.provisionedData.amData", "filter": map[string]interface{}{"ueId": "imsi-208930100007487"}},
+	}
 
-			if tc.expectedMessage == nil {
-				select {
-				case <-configChannel:
-					t.Error("expected no message in configChannel, but got one")
-				default:
-					// No message received, as expected
-				}
-			} else {
-				select {
-				case <-configChannel:
-				default:
-					t.Error("expected message in configChannel, but none received")
-				}
-			}
-		})
+	req, err := http.NewRequest(http.MethodPost, route, bytes.NewBuffer(jsonData))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != expectedCode {
+		t.Errorf("Expected `%v`, got `%v`", expectedCode, w.Code)
+	}
+	if w.Body.String() != expectedBody {
+		t.Errorf("Expected `%v`, got `%v`", expectedBody, w.Body.String())
+	}
+
+	expectedCommonData, _ := json.Marshal(expectedCommonPostDataDetails)
+	gotCommonData, _ := json.Marshal(postDataCommon)
+
+	if !reflect.DeepEqual(expectedCommonData, gotCommonData) {
+		t.Errorf("Expected CommonPostData `%v`, but got `%v`", expectedCommonPostDataDetails, postDataCommon)
+	}
+
+	select {
+	case <-configChannel:
+		t.Error("expected no message in configChannel, but got one")
+	default:
+		// No message received as expected.
 	}
 }
 

--- a/configapi/common_mock_db.go
+++ b/configapi/common_mock_db.go
@@ -144,3 +144,11 @@ func (db *MockMongoClientDuplicateCreation) RestfulAPICount(collName string, fil
 func (m *MockMongoClientDuplicateCreation) StartSession() (mongo.Session, error) {
 	return &MockSession{}, nil
 }
+
+type MockMongoClientNoSubscriberInDB struct {
+	dbadapter.DBInterface
+}
+
+func (db *MockMongoClientNoSubscriberInDB) RestfulAPIGetOne(collName string, filter bson.M) (map[string]interface{}, error) {
+	return nil, nil
+}

--- a/configapi/common_mock_db.go
+++ b/configapi/common_mock_db.go
@@ -147,8 +147,15 @@ func (m *MockMongoClientDuplicateCreation) StartSession() (mongo.Session, error)
 
 type MockMongoClientNoSubscriberInDB struct {
 	dbadapter.DBInterface
+	PostDataCommon *[]map[string]interface{}
 }
 
 func (db *MockMongoClientNoSubscriberInDB) RestfulAPIGetOne(collName string, filter bson.M) (map[string]interface{}, error) {
+	if db.PostDataCommon != nil {
+		*db.PostDataCommon = append(*db.PostDataCommon, map[string]interface{}{
+			"coll":   collName,
+			"filter": filter,
+		})
+	}
 	return nil, nil
 }

--- a/configapi/routers_subconfig.go
+++ b/configapi/routers_subconfig.go
@@ -59,7 +59,7 @@ var apiRoutes = Routes{
 	{
 		"PutSubscriberByID",
 		http.MethodPut,
-		"/subscriber/:ueId/:servingPlmnId",
+		"/subscriber/:ueId",
 		PutSubscriberByID,
 	},
 
@@ -73,7 +73,7 @@ var apiRoutes = Routes{
 	{
 		"PatchSubscriberByID",
 		http.MethodPatch,
-		"/subscriber/:ueId/:servingPlmnId",
+		"/subscriber/:ueId",
 		PatchSubscriberByID,
 	},
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -97,6 +97,55 @@ const docTemplate = `{
                     }
                 }
             },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update subscriber information by IMSI (UE ID)",
+                "tags": [
+                    "Subscribers"
+                ],
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "IMSI (UE ID)",
+                        "name": "imsi",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated subscriber details",
+                        "name": "content",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/configmodels.SubsData"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Subscriber updated successfully"
+                    },
+                    "400": {
+                        "description": "Invalid subscriber content"
+                    },
+                    "401": {
+                        "description": "Authorization failed"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "description": "Subscriber not found"
+                    },
+                    "500": {
+                        "description": "Error updating subscriber"
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -1448,6 +1497,9 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "configmodels.SubsData": {
+            "type": "object"
         },
         "configmodels.SubsListIE": {
             "type": "object",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -138,6 +138,9 @@ const docTemplate = `{
                     "403": {
                         "description": "Forbidden"
                     },
+                    "409": {
+                        "description": "Subscriber already exists"
+                    },
                     "500": {
                         "description": "Error creating subscriber"
                     }


### PR DESCRIPTION
Description:

This PR aims to provide uniqueness for a subscriber's IMSI in the database. 
It protects to override an existing subscriber by returning  `HTTP 409 (Conflict)` error If a subscriber with the given IMSI already exists in the Database.

Previous Behavior:

It does not check if the subscriber with same IMSI exists or not. If the POST request send again, it will override the existing subscriber data.

After this PR:

If a subscriber with the same IMSI exists, it return 409 Conflict error and the existing subscriber data is protected.

