### PR TITLE
feat: return 404 if a subscriber does not exist

### DIFF
--- a/configapi/api_sub_config.go
+++ b/configapi/api_sub_config.go
@@ -316,37 +316,37 @@ func GetSubscriberByID(c *gin.Context) {
 
 	authSubsDataInterface, err := dbadapter.AuthDBClient.RestfulAPIGetOne(authSubsDataColl, filterUeIdOnly)
 	if err != nil {
-		logger.DbLog.Errorf("Failed to fetch authentication subscription data from DB: %v", err)
+		logger.DbLog.Errorf("failed to fetch authentication subscription data from DB: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch the requested user record from DB"})
 		return
 	}
 	amDataDataInterface, err := dbadapter.CommonDBClient.RestfulAPIGetOne(amDataColl, filterUeIdOnly)
 	if err != nil {
-		logger.DbLog.Errorf("Failed to fetch am data from DB: %v", err)
+		logger.DbLog.Errorf("failed to fetch am data from DB: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch the requested user record from DB"})
 		return
 	}
 	smDataDataInterface, err := dbadapter.CommonDBClient.RestfulAPIGetMany(smDataColl, filterUeIdOnly)
 	if err != nil {
-		logger.DbLog.Errorf("Failed to fetch sm data from DB: %v", err)
+		logger.DbLog.Errorf("failed to fetch sm data from DB: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch the requested user record from DB"})
 		return
 	}
 	smfSelDataInterface, err := dbadapter.CommonDBClient.RestfulAPIGetOne(smfSelDataColl, filterUeIdOnly)
 	if err != nil {
-		logger.DbLog.Errorf("Failed to fetch smf selection data from DB: %v", err)
+		logger.DbLog.Errorf("failed to fetch smf selection data from DB: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch the requested user record from DB"})
 		return
 	}
 	amPolicyDataInterface, err := dbadapter.CommonDBClient.RestfulAPIGetOne(amPolicyDataColl, filterUeIdOnly)
 	if err != nil {
-		logger.DbLog.Errorf("Failed to fetch am polict data from DB: %v", err)
+		logger.DbLog.Errorf("failed to fetch am policy data from DB: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch the requested user record from DB"})
 		return
 	}
 	smPolicyDataInterface, err := dbadapter.CommonDBClient.RestfulAPIGetOne(smPolicyDataColl, filterUeIdOnly)
 	if err != nil {
-		logger.DbLog.Errorf("Failed to fetch sm policy data from DB: %v", err)
+		logger.DbLog.Errorf("failed to fetch sm policy data from DB: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch the requested user record from DB"})
 		return
 	}
@@ -366,7 +366,7 @@ func GetSubscriberByID(c *gin.Context) {
 	if authSubsDataInterface != nil {
 		err := json.Unmarshal(configmodels.MapToByte(authSubsDataInterface), &authSubsData)
 		if err != nil {
-			logger.WebUILog.Errorf("Error unmarshalling authentication subscription data: %v", err)
+			logger.WebUILog.Errorf("error unmarshalling authentication subscription data: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve user"})
 			return
 		}
@@ -376,7 +376,7 @@ func GetSubscriberByID(c *gin.Context) {
 	if amDataDataInterface != nil {
 		err := json.Unmarshal(configmodels.MapToByte(amDataDataInterface), &amDataData)
 		if err != nil {
-			logger.WebUILog.Errorf("Error unmarshalling access and mobility subscription data: %v", err)
+			logger.WebUILog.Errorf("error unmarshalling access and mobility subscription data: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve user"})
 			return
 		}
@@ -386,7 +386,7 @@ func GetSubscriberByID(c *gin.Context) {
 	if smDataDataInterface != nil {
 		err := json.Unmarshal(sliceToByte(smDataDataInterface), &smDataData)
 		if err != nil {
-			logger.WebUILog.Errorf("Error unmarshalling session management subscription data: %v", err)
+			logger.WebUILog.Errorf("error unmarshalling session management subscription data: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve user"})
 			return
 		}
@@ -396,7 +396,7 @@ func GetSubscriberByID(c *gin.Context) {
 	if smfSelDataInterface != nil {
 		err := json.Unmarshal(configmodels.MapToByte(smfSelDataInterface), &smfSelData)
 		if err != nil {
-			logger.WebUILog.Errorf("Error unmarshalling smf selection subscription data: %v", err)
+			logger.WebUILog.Errorf("error unmarshalling smf selection subscription data: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve user"})
 			return
 		}
@@ -406,7 +406,7 @@ func GetSubscriberByID(c *gin.Context) {
 	if amPolicyDataInterface != nil {
 		err := json.Unmarshal(configmodels.MapToByte(amPolicyDataInterface), &amPolicyData)
 		if err != nil {
-			logger.WebUILog.Errorf("Error unmarshalling am policy data: %v", err)
+			logger.WebUILog.Errorf("error unmarshalling am policy data: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve user"})
 			return
 		}
@@ -416,7 +416,7 @@ func GetSubscriberByID(c *gin.Context) {
 	if smPolicyDataInterface != nil {
 		err := json.Unmarshal(configmodels.MapToByte(smPolicyDataInterface), &smPolicyData)
 		if err != nil {
-			logger.WebUILog.Errorf("Error unmarshalling sm policy data: %v", err)
+			logger.WebUILog.Errorf("error unmarshalling sm policy data: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve user"})
 			return
 		}

--- a/configapi/api_sub_config.go
+++ b/configapi/api_sub_config.go
@@ -316,27 +316,39 @@ func GetSubscriberByID(c *gin.Context) {
 
 	authSubsDataInterface, err := dbadapter.AuthDBClient.RestfulAPIGetOne(authSubsDataColl, filterUeIdOnly)
 	if err != nil {
-		logger.DbLog.Warnln(err)
+		logger.DbLog.Errorf("Failed to fetch authentication subscription data from DB: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch the requested user record from DB"})
+		return
 	}
 	amDataDataInterface, err := dbadapter.CommonDBClient.RestfulAPIGetOne(amDataColl, filterUeIdOnly)
 	if err != nil {
-		logger.DbLog.Warnln(err)
+		logger.DbLog.Errorf("Failed to fetch am data from DB: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch the requested user record from DB"})
+		return
 	}
 	smDataDataInterface, err := dbadapter.CommonDBClient.RestfulAPIGetMany(smDataColl, filterUeIdOnly)
 	if err != nil {
-		logger.DbLog.Warnln(err)
+		logger.DbLog.Errorf("Failed to fetch sm data from DB: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch the requested user record from DB"})
+		return
 	}
 	smfSelDataInterface, err := dbadapter.CommonDBClient.RestfulAPIGetOne(smfSelDataColl, filterUeIdOnly)
 	if err != nil {
-		logger.DbLog.Warnln(err)
+		logger.DbLog.Errorf("Failed to fetch smf selection data from DB: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch the requested user record from DB"})
+		return
 	}
 	amPolicyDataInterface, err := dbadapter.CommonDBClient.RestfulAPIGetOne(amPolicyDataColl, filterUeIdOnly)
 	if err != nil {
-		logger.DbLog.Warnln(err)
+		logger.DbLog.Errorf("Failed to fetch am polict data from DB: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch the requested user record from DB"})
+		return
 	}
 	smPolicyDataInterface, err := dbadapter.CommonDBClient.RestfulAPIGetOne(smPolicyDataColl, filterUeIdOnly)
 	if err != nil {
-		logger.DbLog.Warnln(err)
+		logger.DbLog.Errorf("Failed to fetch sm policy data from DB: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch the requested user record from DB"})
+		return
 	}
 	// If all fetched data is empty, return 404 error
 	if authSubsDataInterface == nil &&
@@ -354,7 +366,8 @@ func GetSubscriberByID(c *gin.Context) {
 	if authSubsDataInterface != nil {
 		err := json.Unmarshal(configmodels.MapToByte(authSubsDataInterface), &authSubsData)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to unmarshal authentication subscription data"})
+			logger.WebUILog.Errorf("Error unmarshalling authentication subscription data: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve user"})
 			return
 		}
 	}
@@ -363,7 +376,8 @@ func GetSubscriberByID(c *gin.Context) {
 	if amDataDataInterface != nil {
 		err := json.Unmarshal(configmodels.MapToByte(amDataDataInterface), &amDataData)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to unmarshal access and mobility subscription data"})
+			logger.WebUILog.Errorf("Error unmarshalling access and mobility subscription data: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve user"})
 			return
 		}
 	}
@@ -372,7 +386,8 @@ func GetSubscriberByID(c *gin.Context) {
 	if smDataDataInterface != nil {
 		err := json.Unmarshal(sliceToByte(smDataDataInterface), &smDataData)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to unmarshal session management subscription data"})
+			logger.WebUILog.Errorf("Error unmarshalling session management subscription data: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve user"})
 			return
 		}
 	}
@@ -381,7 +396,8 @@ func GetSubscriberByID(c *gin.Context) {
 	if smfSelDataInterface != nil {
 		err := json.Unmarshal(configmodels.MapToByte(smfSelDataInterface), &smfSelData)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to unmarshal smf selection subscription data"})
+			logger.WebUILog.Errorf("Error unmarshalling smf selection subscription data: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve user"})
 			return
 		}
 	}
@@ -390,7 +406,8 @@ func GetSubscriberByID(c *gin.Context) {
 	if amPolicyDataInterface != nil {
 		err := json.Unmarshal(configmodels.MapToByte(amPolicyDataInterface), &amPolicyData)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to unmarshal am policy data"})
+			logger.WebUILog.Errorf("Error unmarshalling am policy data: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve user"})
 			return
 		}
 	}
@@ -399,7 +416,8 @@ func GetSubscriberByID(c *gin.Context) {
 	if smPolicyDataInterface != nil {
 		err := json.Unmarshal(configmodels.MapToByte(smPolicyDataInterface), &smPolicyData)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to unmarshal sm policy data"})
+			logger.WebUILog.Errorf("Error unmarshalling sm policy data: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve user"})
 			return
 		}
 	}

--- a/configapi/api_sub_config.go
+++ b/configapi/api_sub_config.go
@@ -357,7 +357,7 @@ func GetSubscriberByID(c *gin.Context) {
 		smfSelDataInterface == nil &&
 		amPolicyDataInterface == nil &&
 		smPolicyDataInterface == nil {
-		logger.WebUILog.Warnf("subscriber with ID %s not found", ueId)
+		logger.WebUILog.Errorf("subscriber with ID %s not found", ueId)
 		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("subscriber with ID %s not found", ueId)})
 		return
 	}

--- a/configapi/api_sub_config_test.go
+++ b/configapi/api_sub_config_test.go
@@ -75,12 +75,12 @@ func (m *MockMongoClientDeviceGroupsWithSubscriber) RestfulAPIGetMany(coll strin
 
 type MockAuthDBClientEmpty struct {
 	dbadapter.DBInterface
-	PostData *[]map[string]interface{}
+	PostDataAuth *[]map[string]interface{}
 }
 
 func (m *MockAuthDBClientEmpty) RestfulAPIGetOne(coll string, filter bson.M) (map[string]interface{}, error) {
-	if m.PostData != nil {
-		*m.PostData = append(*m.PostData, map[string]interface{}{
+	if m.PostDataAuth != nil {
+		*m.PostDataAuth = append(*m.PostDataAuth, map[string]interface{}{
 			"coll":   coll,
 			"filter": filter,
 		})
@@ -90,51 +90,54 @@ func (m *MockAuthDBClientEmpty) RestfulAPIGetOne(coll string, filter bson.M) (ma
 
 type MockAuthDBClientWithData struct {
 	dbadapter.DBInterface
-	PostData *[]map[string]interface{}
+	PostDataAuth *[]map[string]interface{}
 }
 
 func (m *MockAuthDBClientWithData) RestfulAPIGetOne(coll string, filter bson.M) (map[string]interface{}, error) {
-	if m.PostData != nil {
-		*m.PostData = append(*m.PostData, map[string]interface{}{
+	if m.PostDataAuth != nil {
+		*m.PostDataAuth = append(*m.PostDataAuth, map[string]interface{}{
 			"coll":   coll,
 			"filter": filter,
 		})
 	}
-	if coll == "subscriptionData.authenticationData.authenticationSubscription" && filter["ueId"] != nil {
-		return map[string]interface{}{
-			"AuthenticationManagementField": "8000",
-			"AuthenticationMethod":          "5G_AKA",
-			"Milenage": map[string]interface{}{
-				"Op": map[string]interface{}{
-					"EncryptionAlgorithm": 0,
-					"EncryptionKey":       0,
-					"OpValue":             "",
-				},
+	authSubscription := &models.AuthenticationSubscription{
+		AuthenticationManagementField: "8000",
+		AuthenticationMethod:          "5G_AKA",
+		Milenage: &models.Milenage{
+			Op: &models.Op{
+				EncryptionAlgorithm: 0,
+				EncryptionKey:       0,
+				OpValue:             "c9e8763286b5b9ffbdf56e1297d0887b",
 			},
-			"Opc": map[string]interface{}{
-				"EncryptionAlgorithm": 0,
-				"EncryptionKey":       0,
-				"OpcValue":            "8e27b6af0e692e750f32667a3b14605d",
-			},
-			"PermanentKey": map[string]interface{}{
-				"EncryptionAlgorithm": 0,
-				"EncryptionKey":       0,
-				"Value":               "8baf473f2f8fd09487cccbd7097c6862",
-			},
-			"SequenceNumber": "16f3b3f70fc2",
-		}, nil
+		},
+		Opc: &models.Opc{
+			EncryptionAlgorithm: 0,
+			EncryptionKey:       0,
+			OpcValue:            "981d464c7c52eb6e5036234984ad0bcf",
+		},
+		PermanentKey: &models.PermanentKey{
+			EncryptionAlgorithm: 0,
+			EncryptionKey:       0,
+			PermanentKeyValue:   "5122250214c33e723a5dd523fc145fc0",
+		},
+		SequenceNumber: "16f3b3f70fc2",
 	}
-	return nil, fmt.Errorf("collection %s not found", coll)
+	tmp, _ := json.Marshal(authSubscription)
+	var result map[string]interface{}
+	json.Unmarshal(tmp, &result)
+
+	return result, nil
+
 }
 
 type MockCommonDBClientEmpty struct {
 	dbadapter.DBInterface
-	PostData *[]map[string]interface{}
+	PostDataCommon *[]map[string]interface{}
 }
 
 func (m *MockCommonDBClientEmpty) RestfulAPIGetOne(coll string, filter bson.M) (map[string]interface{}, error) {
-	if m.PostData != nil {
-		*m.PostData = append(*m.PostData, map[string]interface{}{
+	if m.PostDataCommon != nil {
+		*m.PostDataCommon = append(*m.PostDataCommon, map[string]interface{}{
 			"coll":   coll,
 			"filter": filter,
 		})
@@ -144,8 +147,8 @@ func (m *MockCommonDBClientEmpty) RestfulAPIGetOne(coll string, filter bson.M) (
 }
 
 func (m *MockCommonDBClientEmpty) RestfulAPIGetMany(coll string, filter bson.M) ([]map[string]interface{}, error) {
-	if m.PostData != nil {
-		*m.PostData = append(*m.PostData, map[string]interface{}{
+	if m.PostDataCommon != nil {
+		*m.PostDataCommon = append(*m.PostDataCommon, map[string]interface{}{
 			"coll":   coll,
 			"filter": filter,
 		})
@@ -155,166 +158,310 @@ func (m *MockCommonDBClientEmpty) RestfulAPIGetMany(coll string, filter bson.M) 
 
 type MockCommonDBClientWithData struct {
 	dbadapter.DBInterface
-	PostData *[]map[string]interface{}
+	PostDataCommon *[]map[string]interface{}
 }
 
 func (m *MockCommonDBClientWithData) RestfulAPIGetOne(coll string, filter bson.M) (map[string]interface{}, error) {
-	if m.PostData != nil {
-		*m.PostData = append(*m.PostData, map[string]interface{}{
+	if m.PostDataCommon != nil {
+		*m.PostDataCommon = append(*m.PostDataCommon, map[string]interface{}{
 			"coll":   coll,
 			"filter": filter,
 		})
 	}
-	ueId, ok := filter["ueId"].(string)
-	if !ok {
-		return nil, fmt.Errorf("invalid or missing ueId in filter")
-	}
 
 	switch coll {
 	case "subscriptionData.provisionedData.amData":
-		imsi := ueId
-		mcc, mnc := "001", "100"
-
-		return map[string]interface{}{
-			"ueId":           "imsi-" + imsi,
-			"servingPlmnId":  mcc + mnc,
-			"data":           "access management data",
-			"filterCriteria": filter,
-		}, nil
-
-	case "policyData.ues.amData":
-		return map[string]interface{}{
-			"ueId":   ueId,
-			"amData": "access management data",
-		}, nil
-
-	case "policyData.ues.smData":
-		return map[string]interface{}{
-			"ueId":   ueId,
-			"smData": "session policy data",
-		}, nil
-
-	case "subscriptionData.provisionedData.smfSelectionSubscriptionData":
-		return map[string]interface{}{
-			"ueId":          ueId,
-			"servingPlmnId": "001100",
-			"SubscribedSnssaiInfos": map[string]interface{}{
-				"010203": map[string]interface{}{
-					"DnnInfos": []map[string]string{
-						{"Dnn": "internet"},
+		amDataData := models.AccessAndMobilitySubscriptionData{
+			Gpsis: []string{
+				"msisdn-0900000000",
+			},
+			Nssai: &models.Nssai{
+				DefaultSingleNssais: []models.Snssai{
+					{
+						Sd:  "010203",
+						Sst: 1,
+					},
+				},
+				SingleNssais: []models.Snssai{
+					{
+						Sd:  "010203",
+						Sst: 1,
 					},
 				},
 			},
-		}, nil
+			SubscribedUeAmbr: &models.AmbrRm{
+				Downlink: "1000 Kbps",
+				Uplink:   "1000 Kbps",
+			},
+		}
+		tmp, _ := json.Marshal(amDataData)
+		var result map[string]interface{}
+		json.Unmarshal(tmp, &result)
+		return result, nil
+
+	case "policyData.ues.amData":
+		amPolicyData := models.AmPolicyData{
+			SubscCats: []string{
+				"aether",
+			},
+		}
+		tmp, _ := json.Marshal(amPolicyData)
+		var result map[string]interface{}
+		json.Unmarshal(tmp, &result)
+		return result, nil
+
+	case "policyData.ues.smData":
+		smPolicyData := models.SmPolicyData{
+			SmPolicySnssaiData: map[string]models.SmPolicySnssaiData{
+				"01010203": {
+					Snssai: &models.Snssai{
+						Sd:  "010203",
+						Sst: 1,
+					},
+					SmPolicyDnnData: map[string]models.SmPolicyDnnData{
+						"internet": {
+							Dnn: "internet",
+						},
+					},
+				},
+			},
+		}
+		tmp, _ := json.Marshal(smPolicyData)
+		var result map[string]interface{}
+		json.Unmarshal(tmp, &result)
+		return result, nil
+
+	case "subscriptionData.provisionedData.smfSelectionSubscriptionData":
+		smfSelData := models.SmfSelectionSubscriptionData{
+			SubscribedSnssaiInfos: map[string]models.SnssaiInfo{
+				"01010203": {
+					DnnInfos: []models.DnnInfo{
+						{
+							Dnn: "internet",
+						},
+					},
+				},
+			},
+		}
+		tmp, _ := json.Marshal(smfSelData)
+		var result map[string]interface{}
+		json.Unmarshal(tmp, &result)
+		return result, nil
+
 	default:
 		return nil, fmt.Errorf("collection %s not found", coll)
 	}
 }
 
 func (m *MockCommonDBClientWithData) RestfulAPIGetMany(coll string, filter bson.M) ([]map[string]interface{}, error) {
-	if m.PostData != nil {
-		*m.PostData = append(*m.PostData, map[string]interface{}{
+	if m.PostDataCommon != nil {
+		*m.PostDataCommon = append(*m.PostDataCommon, map[string]interface{}{
 			"coll":   coll,
 			"filter": filter,
 		})
 	}
-	if coll == "subscriptionData.provisionedData.smData" && filter["ueId"] != nil {
-		return []map[string]interface{}{
-			{
-				"ueId": filter["ueId"],
-				"data": "session management data",
+	smDataData := []models.SessionManagementSubscriptionData{
+		{
+			SingleNssai: &models.Snssai{
+				Sst: 1,
+				Sd:  "010203",
 			},
-		}, nil
+			DnnConfigurations: map[string]models.DnnConfiguration{
+				"internet": {
+					PduSessionTypes: &models.PduSessionTypes{
+						DefaultSessionType:  models.PduSessionType_IPV4,
+						AllowedSessionTypes: []models.PduSessionType{models.PduSessionType_IPV4},
+					},
+					SscModes: &models.SscModes{
+						DefaultSscMode:  models.SscMode__1,
+						AllowedSscModes: []models.SscMode{models.SscMode__1},
+					},
+					SessionAmbr: &models.Ambr{
+						Downlink: "1000 Kbps",
+						Uplink:   "1000 Kbps",
+					},
+					Var5gQosProfile: &models.SubscribedDefaultQos{
+						Var5qi: 9,
+						Arp: &models.Arp{
+							PriorityLevel: 8,
+						},
+						PriorityLevel: 8,
+					},
+				},
+			},
+		},
 	}
-	return nil, fmt.Errorf("collection %s not found", coll)
-}
-
-func comparePostData(expected, actual []map[string]interface{}) error {
-	if len(expected) != len(actual) {
-		return fmt.Errorf("length mismatch: expected %d elements, got %d elements", len(expected), len(actual))
-	}
-
-	for i := range expected {
-		if !compareMaps(expected[i], actual[i]) {
-			return fmt.Errorf("mismatch at index %d: expected %+v, got %+v", i, expected[i], actual[i])
+	result := make([]map[string]interface{}, len(smDataData))
+	for i, smData := range smDataData {
+		result[i] = map[string]interface{}{
+			"SingleNssai":       smData.SingleNssai,
+			"DnnConfigurations": smData.DnnConfigurations,
 		}
 	}
-
-	return nil
-}
-
-func compareMaps(map1, map2 map[string]interface{}) bool {
-	if len(map1) != len(map2) {
-		return false
-	}
-	for key, val1 := range map1 {
-		val2, exists := map2[key]
-		if !exists {
-			return false
-		}
-		if fmt.Sprintf("%v", val1) != fmt.Sprintf("%v", val2) {
-			return false
-		}
-	}
-	return true
+	return result, nil
 }
 
 func TestGetSubscriberByID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
 	AddApiService(router)
-	postData := make([]map[string]interface{}, 0)
+	postDataCommon := make([]map[string]interface{}, 0)
+	postDataAuth := make([]map[string]interface{}, 0)
 
 	tests := []struct {
-		name                    string
-		ueId                    string
-		route                   string
-		commonDbAdapter         dbadapter.DBInterface
-		authDbAdapter           dbadapter.DBInterface
-		expectedHTTPStatus      int
-		expectedCollections     []string
-		expectedFullResponse    string
-		expectedPostDataDetails []map[string]interface{}
+		name                          string
+		ueId                          string
+		route                         string
+		commonDbAdapter               dbadapter.DBInterface
+		authDbAdapter                 dbadapter.DBInterface
+		expectedHTTPStatus            int
+		expectedFullResponse          map[string]interface{}
+		expectedCommonPostDataDetails []map[string]interface{}
+		expectedAuthPostDataDetails   []map[string]interface{}
 	}{
 		{
 			name:                 "No subscriber data found",
-			ueId:                 "12345",
+			ueId:                 "imsi-2089300007487",
 			route:                "/api/subscriber/:ueId",
-			commonDbAdapter:      &MockCommonDBClientEmpty{PostData: &postData},
-			authDbAdapter:        &MockAuthDBClientEmpty{PostData: &postData},
+			commonDbAdapter:      &MockCommonDBClientEmpty{PostDataCommon: &postDataCommon},
+			authDbAdapter:        &MockAuthDBClientEmpty{PostDataAuth: &postDataAuth},
 			expectedHTTPStatus:   http.StatusNotFound,
-			expectedFullResponse: `{"error":"subscriber with ID 12345 not found"}`,
-			expectedPostDataDetails: []map[string]interface{}{
-				{"coll": "subscriptionData.authenticationData.authenticationSubscription", "filter": map[string]interface{}{"ueId": "12345"}},
-				{"coll": "subscriptionData.provisionedData.amData", "filter": map[string]interface{}{"ueId": "12345"}},
-				{"coll": "subscriptionData.provisionedData.smData", "filter": map[string]interface{}{"ueId": "12345"}},
-				{"coll": "subscriptionData.provisionedData.smfSelectionSubscriptionData", "filter": map[string]interface{}{"ueId": "12345"}},
-				{"coll": "policyData.ues.amData", "filter": map[string]interface{}{"ueId": "12345"}},
-				{"coll": "policyData.ues.smData", "filter": map[string]interface{}{"ueId": "12345"}},
+			expectedFullResponse: map[string]interface{}{"error": "subscriber with ID imsi-2089300007487 not found"},
+			expectedCommonPostDataDetails: []map[string]interface{}{
+				{"coll": "subscriptionData.provisionedData.amData", "filter": map[string]interface{}{"ueId": "imsi-2089300007487"}},
+				{"coll": "subscriptionData.provisionedData.smData", "filter": map[string]interface{}{"ueId": "imsi-2089300007487"}},
+				{"coll": "subscriptionData.provisionedData.smfSelectionSubscriptionData", "filter": map[string]interface{}{"ueId": "imsi-2089300007487"}},
+				{"coll": "policyData.ues.amData", "filter": map[string]interface{}{"ueId": "imsi-2089300007487"}},
+				{"coll": "policyData.ues.smData", "filter": map[string]interface{}{"ueId": "imsi-2089300007487"}},
+			},
+			expectedAuthPostDataDetails: []map[string]interface{}{
+				{"coll": "subscriptionData.authenticationData.authenticationSubscription", "filter": map[string]interface{}{"ueId": "imsi-2089300007487"}},
 			},
 		},
 
 		{
-			name:                 "Valid subscriber data retrieved",
-			ueId:                 "12345",
-			commonDbAdapter:      &MockCommonDBClientWithData{PostData: &postData},
-			authDbAdapter:        &MockAuthDBClientWithData{PostData: &postData},
-			route:                "/api/subscriber/:ueId",
-			expectedHTTPStatus:   http.StatusOK,
-			expectedFullResponse: `{"plmnID":"","ueId":"12345","AuthenticationSubscription":{"authenticationMethod":"5G_AKA","permanentKey":{"permanentKeyValue":"","encryptionKey":0,"encryptionAlgorithm":0},"sequenceNumber":"16f3b3f70fc2","authenticationManagementField":"8000","milenage":{"op":{"opValue":"","encryptionKey":0,"encryptionAlgorithm":0}},"opc":{"opcValue":"8e27b6af0e692e750f32667a3b14605d","encryptionKey":0,"encryptionAlgorithm":0}},"AccessAndMobilitySubscriptionData":{},"SessionManagementSubscriptionData":[{"singleNssai":null}],"SmfSelectionSubscriptionData":{"subscribedSnssaiInfos":{"010203":{"dnnInfos":[{"dnn":"internet"}]}}},"AmPolicyData":{},"SmPolicyData":{"smPolicySnssaiData":null},"FlowRules":null}`,
-			expectedPostDataDetails: []map[string]interface{}{
-				{"coll": "subscriptionData.authenticationData.authenticationSubscription", "filter": map[string]interface{}{"ueId": "12345"}},
-				{"coll": "subscriptionData.provisionedData.amData", "filter": map[string]interface{}{"ueId": "12345"}},
-				{"coll": "subscriptionData.provisionedData.smData", "filter": map[string]interface{}{"ueId": "12345"}},
-				{"coll": "subscriptionData.provisionedData.smfSelectionSubscriptionData", "filter": map[string]interface{}{"ueId": "12345"}},
-				{"coll": "policyData.ues.amData", "filter": map[string]interface{}{"ueId": "12345"}},
-				{"coll": "policyData.ues.smData", "filter": map[string]interface{}{"ueId": "12345"}},
+			name:               "Valid subscriber data retrieved",
+			ueId:               "imsi-2089300007487",
+			commonDbAdapter:    &MockCommonDBClientWithData{PostDataCommon: &postDataCommon},
+			authDbAdapter:      &MockAuthDBClientWithData{PostDataAuth: &postDataAuth},
+			route:              "/api/subscriber/:ueId",
+			expectedHTTPStatus: http.StatusOK,
+			expectedFullResponse: map[string]interface{}{
+				"AccessAndMobilitySubscriptionData": map[string]interface{}{
+					"gpsis": []interface{}{"msisdn-0900000000"},
+					"nssai": map[string]interface{}{
+						"defaultSingleNssais": []interface{}{
+							map[string]interface{}{"sd": "010203", "sst": 1},
+						},
+						"singleNssais": []interface{}{
+							map[string]interface{}{"sd": "010203", "sst": 1},
+						},
+					},
+					"subscribedUeAmbr": map[string]interface{}{
+						"downlink": "1000 Kbps",
+						"uplink":   "1000 Kbps",
+					},
+				},
+				"AmPolicyData": map[string]interface{}{
+					"subscCats": []interface{}{"aether"},
+				},
+				"AuthenticationSubscription": map[string]interface{}{
+					"authenticationManagementField": "8000",
+					"authenticationMethod":          "5G_AKA",
+					"milenage": map[string]interface{}{
+						"op": map[string]interface{}{
+							"encryptionAlgorithm": 0,
+							"encryptionKey":       0,
+							"opValue":             "c9e8763286b5b9ffbdf56e1297d0887b",
+						},
+					},
+					"opc": map[string]interface{}{
+						"encryptionAlgorithm": 0,
+						"encryptionKey":       0,
+						"opcValue":            "981d464c7c52eb6e5036234984ad0bcf",
+					},
+					"permanentKey": map[string]interface{}{
+						"encryptionAlgorithm": 0,
+						"encryptionKey":       0,
+						"permanentKeyValue":   "5122250214c33e723a5dd523fc145fc0",
+					},
+					"sequenceNumber": "16f3b3f70fc2",
+				},
+				"FlowRules": nil,
+				"SessionManagementSubscriptionData": []interface{}{
+					map[string]interface{}{
+						"dnnConfigurations": map[string]interface{}{
+							"internet": map[string]interface{}{
+								"5gQosProfile": map[string]interface{}{
+									"5qi":           9,
+									"arp":           map[string]interface{}{"preemptCap": "", "preemptVuln": "", "priorityLevel": 8},
+									"priorityLevel": 8,
+								},
+								"pduSessionTypes": map[string]interface{}{
+									"allowedSessionTypes": []interface{}{"IPV4"},
+									"defaultSessionType":  "IPV4",
+								},
+								"sessionAmbr": map[string]interface{}{
+									"downlink": "1000 Kbps",
+									"uplink":   "1000 Kbps",
+								},
+								"sscModes": map[string]interface{}{
+									"allowedSscModes": []interface{}{"SSC_MODE_1"},
+									"defaultSscMode":  "SSC_MODE_1",
+								},
+							},
+						},
+						"singleNssai": map[string]interface{}{
+							"sd":  "010203",
+							"sst": 1,
+						},
+					},
+				},
+				"SmPolicyData": map[string]interface{}{
+					"smPolicySnssaiData": map[string]interface{}{
+						"01010203": map[string]interface{}{
+							"smPolicyDnnData": map[string]interface{}{
+								"internet": map[string]interface{}{
+									"dnn": "internet",
+								},
+							},
+							"snssai": map[string]interface{}{
+								"sd":  "010203",
+								"sst": 1,
+							},
+						},
+					},
+				},
+				"SmfSelectionSubscriptionData": map[string]interface{}{
+					"subscribedSnssaiInfos": map[string]interface{}{
+						"01010203": map[string]interface{}{
+							"dnnInfos": []interface{}{
+								map[string]interface{}{
+									"dnn": "internet",
+								},
+							},
+						},
+					},
+				},
+				"plmnID": "",
+				"ueId":   "imsi-2089300007487",
+			},
+			expectedCommonPostDataDetails: []map[string]interface{}{
+				{"coll": "subscriptionData.provisionedData.amData", "filter": map[string]interface{}{"ueId": "imsi-2089300007487"}},
+				{"coll": "subscriptionData.provisionedData.smData", "filter": map[string]interface{}{"ueId": "imsi-2089300007487"}},
+				{"coll": "subscriptionData.provisionedData.smfSelectionSubscriptionData", "filter": map[string]interface{}{"ueId": "imsi-2089300007487"}},
+				{"coll": "policyData.ues.amData", "filter": map[string]interface{}{"ueId": "imsi-2089300007487"}},
+				{"coll": "policyData.ues.smData", "filter": map[string]interface{}{"ueId": "imsi-2089300007487"}},
+			},
+			expectedAuthPostDataDetails: []map[string]interface{}{
+				{"coll": "subscriptionData.authenticationData.authenticationSubscription", "filter": map[string]interface{}{"ueId": "imsi-2089300007487"}},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			postData = nil
+			postDataCommon = nil
+			postDataAuth = nil
 			originalAuthDBClient := dbadapter.AuthDBClient
 			originalCommonDBClient := dbadapter.CommonDBClient
 			dbadapter.CommonDBClient = tt.commonDbAdapter
@@ -329,13 +476,37 @@ func TestGetSubscriberByID(t *testing.T) {
 
 			router.ServeHTTP(w, req)
 
-			responseContent := w.Body.String()
-			if !reflect.DeepEqual(responseContent, tt.expectedFullResponse) {
-				t.Errorf("Expected full response body `%v`, but got `%v`", tt.expectedFullResponse, responseContent)
+			if w.Code != tt.expectedHTTPStatus {
+				t.Errorf("Expected HTTP status %d, got %d", tt.expectedHTTPStatus, w.Code)
 			}
 
-			if comparePostData(tt.expectedPostDataDetails, postData) != nil {
-				t.Errorf("Expected postData `%v`, but got `%v`", tt.expectedPostDataDetails, postData)
+			responseContent := w.Body.String()
+			var actual, expected map[string]interface{}
+			if err := json.Unmarshal([]byte(responseContent), &actual); err != nil {
+				t.Fatalf("Failed to unmarshal actual response: %v. Raw response: %s", err, responseContent)
+			}
+			expectedJSON, _ := json.Marshal(tt.expectedFullResponse)
+			_ = json.Unmarshal(expectedJSON, &expected)
+
+			expectedResponse, _ := json.Marshal(expected)
+			actualResponse, _ := json.Marshal(actual)
+
+			if !reflect.DeepEqual(expectedResponse, actualResponse) {
+				t.Errorf("Mismatch in response:\nExpected:\n%s\nGot:\n%s\n", string(expectedResponse), string(actualResponse))
+			}
+
+			expectedCommonData, _ := json.Marshal(tt.expectedCommonPostDataDetails)
+			gotCommonData, _ := json.Marshal(postDataCommon)
+
+			if !reflect.DeepEqual(expectedCommonData, gotCommonData) {
+				t.Errorf("Expected CommonPostData `%v`, but got `%v`", tt.expectedAuthPostDataDetails, postDataAuth)
+			}
+
+			expectedAuthData, _ := json.Marshal(tt.expectedAuthPostDataDetails)
+			gotAuthData, _ := json.Marshal(postDataAuth)
+
+			if !reflect.DeepEqual(expectedAuthData, gotAuthData) {
+				t.Errorf("Expected AuthPostData `%v`, but got `%v`", tt.expectedAuthPostDataDetails, postDataAuth)
 			}
 		})
 	}

--- a/configapi/api_sub_config_test.go
+++ b/configapi/api_sub_config_test.go
@@ -499,7 +499,7 @@ func TestGetSubscriberByID(t *testing.T) {
 			gotCommonData, _ := json.Marshal(postDataCommon)
 
 			if !reflect.DeepEqual(expectedCommonData, gotCommonData) {
-				t.Errorf("Expected CommonPostData `%v`, but got `%v`", tt.expectedAuthPostDataDetails, postDataAuth)
+				t.Errorf("Expected CommonPostData `%v`, but got `%v`", tt.expectedCommonPostDataDetails, postDataCommon)
 			}
 
 			expectedAuthData, _ := json.Marshal(tt.expectedAuthPostDataDetails)


### PR DESCRIPTION
Previous Behavior:
If a subscriber is not found in the DB, it returns an object with empty values as below:

```
{"plmnID":"","ueId":<subscriber>,"AuthenticationSubscription":{"authenticationMethod":"","permanentKey":null,"sequenceNumber":""},"AccessAndMobilitySubscriptionData":{},"SessionManagementSubscriptionData":null,"SmfSelectionSubscriptionData":{},"AmPolicyData":{},"SmPolicyData":{"smPolicySnssaiData":null},"FlowRules":null}
```

After this PR:

If a subscriber is not found in the DB, it will respond with `404 Not Found`.

Fixes https://github.com/omec-project/webconsole/issues/109.