### PR TITLE
feat: allow creation of gNBs without TAC

### DIFF
--- a/configapi/api_inventory.go
+++ b/configapi/api_inventory.go
@@ -90,11 +90,13 @@ func PostGnb(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": errorMessage})
 		return
 	}
-	if !isValidGnbTac(postGnbParams.Tac) {
-		errorMessage := fmt.Sprintf("invalid gNB TAC '%v'. TAC must be a numeric string within the range [1, 16777215]", postGnbParams.Tac)
-		logger.WebUILog.Errorln(errorMessage)
-		c.JSON(http.StatusBadRequest, gin.H{"error": errorMessage})
-		return
+	if postGnbParams.Tac != "" {
+		if !isValidGnbTac(postGnbParams.Tac) {
+			errorMessage := fmt.Sprintf("invalid gNB TAC '%v'. TAC must be a numeric string within the range [1, 16777215]", postGnbParams.Tac)
+			logger.WebUILog.Errorln(errorMessage)
+			c.JSON(http.StatusBadRequest, gin.H{"error": errorMessage})
+			return
+		}
 	}
 	gnb := configmodels.Gnb(postGnbParams)
 	if err := executeGnbTransaction(c.Request.Context(), gnb, updateGnbInNetworkSlices, postGnbOperation); err != nil {

--- a/configapi/api_inventory_test.go
+++ b/configapi/api_inventory_test.go
@@ -234,6 +234,14 @@ func TestGnbPostHandler(t *testing.T) {
 			expectedBody: "{}",
 		},
 		{
+			name:         "Create a new gNB without TAC expects created status",
+			route:        "/config/v1/inventory/gnb",
+			dbAdapter:    &MockMongoClientEmptyDB{},
+			inputData:    `{"name": "gnb1"}`,
+			expectedCode: http.StatusCreated,
+			expectedBody: "{}",
+		},
+		{
 			name:         "Create an existing gNB expects failure",
 			route:        "/config/v1/inventory/gnb",
 			dbAdapter:    &MockMongoClientDuplicateCreation{},
@@ -248,14 +256,6 @@ func TestGnbPostHandler(t *testing.T) {
 			inputData:    `{"name": "gnb1", "tac": 123}`,
 			expectedCode: http.StatusBadRequest,
 			expectedBody: `{"error":"invalid JSON format"}`,
-		},
-		{
-			name:         "Missing TAC expects failure",
-			route:        "/config/v1/inventory/gnb",
-			dbAdapter:    &MockMongoClientEmptyDB{},
-			inputData:    `{"name": "gnb1"}`,
-			expectedCode: http.StatusBadRequest,
-			expectedBody: `{"error":"invalid gNB TAC ''. TAC must be a numeric string within the range [1, 16777215]"}`,
 		},
 		{
 			name:         "DB POST operation fails expects failure",

--- a/configmodels/model_inventory.go
+++ b/configmodels/model_inventory.go
@@ -10,12 +10,12 @@ const (
 
 type Gnb struct {
 	Name string `json:"name"`
-	Tac  string `json:"tac"`
+	Tac  string `json:"tac,omitempty"`
 }
 
 type PostGnbRequest struct {
 	Name string `json:"name"`
-	Tac  string `json:"tac"`
+	Tac  string `json:"tac,omitempty"`
 }
 
 type PutGnbRequest struct {


### PR DESCRIPTION
This PR allows the provisioning of gNBs in inventory (`POST /config/v1/inventory/gnbs`) without the need to specify the TAC.

### Rationale
We are proposing this change to improve the network configuration orchestration between Core and the RAN. Currently, all the CUs integrated with the Core are mapped to different gNBs objects which are created with an hardcoded value for the TAC (`1`). When the network configuration (in particular a Network Slice with such gNB defined in the `Site` information) is available, the gNB in webconsole is updated and the TAC (along other network configuration information) is propagated to the RAN leveraging the [Pebble notices](https://github.com/omec-project/webconsole/pull/250).
This PR is necessary since the [NMS Operator](https://github.com/canonical/sdcore-nms-k8s-operator) hardcodes the value `1` as TAC, preventing the users to select a different value (which will be eventually be reset to 1 at some point).