### PR TITLE
fix: duplicate user account returns 409 conflict

### DIFF
--- a/configapi/handlers_user_account.go
+++ b/configapi/handlers_user_account.go
@@ -131,6 +131,7 @@ func fetchDBUserAccount(username string) (*configmodels.DBUserAccount, error) {
 // @Failure      401  {object}  nil  "Authorization failed"
 // @Failure      403  {object}  nil  "Forbidden"
 // @Failure      404  {object}  nil  "Page not found if enableAuthentication is disabled"
+// @Failure      409  {object}  nil  "User account already exists"
 // @Failure      500  {object}  nil  "Failed to create the user account"
 // @Router      /config/v1/account/  [post]
 func CreateUserAccount(c *gin.Context) {
@@ -175,7 +176,7 @@ func CreateUserAccount(c *gin.Context) {
 	if err != nil {
 		if strings.Contains(err.Error(), "E11000") {
 			logger.DbLog.Errorln("Duplicate username found:", err)
-			c.JSON(http.StatusBadRequest, gin.H{"error": "user account already exists"})
+			c.JSON(http.StatusConflict, gin.H{"error": "user account already exists"})
 			return
 		}
 		logger.DbLog.Errorln(err.Error())

--- a/configapi/handlers_user_account_test.go
+++ b/configapi/handlers_user_account_test.go
@@ -226,7 +226,7 @@ func TestCreateUserAccountHandler(t *testing.T) {
 			name:         "UserThatAlreadyExists",
 			dbAdapter:    &MockMongoClientDuplicateCreation{},
 			inputData:    `{"username": "janedoe", "password" : "Admin1234"}`,
-			expectedCode: http.StatusBadRequest,
+			expectedCode: http.StatusConflict,
 			expectedBody: `{"error":"user account already exists"}`,
 		},
 		{

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -308,6 +308,9 @@ const docTemplate = `{
                     "404": {
                         "description": "Page not found if enableAuthentication is disabled"
                     },
+                    "409": {
+                        "description": "User account already exists"
+                    },
                     "500": {
                         "description": "Failed to create the user account"
                     }
@@ -678,7 +681,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "201": {
-                        "description": "gNB sucessfully created"
+                        "description": "gNB successfully created"
                     },
                     "400": {
                         "description": "Bad request"
@@ -729,7 +732,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "201": {
-                        "description": "gNB sucessfully created"
+                        "description": "gNB successfully created"
                     },
                     "400": {
                         "description": "Bad request"


### PR DESCRIPTION
This PR modifies the Create User account operation to return a 409 Conflict error if the user account already exists instead of a 400 Bad request