### PR TITLE
chore: enable staticcheck linter in CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,13 +22,13 @@ linters:
     - misspell
     - nakedret
     - predeclared
+    - staticcheck
     - unconvert
     - unparam
     - whitespace
   disable:
     - errcheck
     - govet
-    - staticcheck
   settings:
     errcheck:
       check-type-assertions: false

--- a/backend/webui_service/webui_init.go
+++ b/backend/webui_service/webui_init.go
@@ -236,7 +236,7 @@ func (webui *WEBUI) Start() {
 
 	// Start grpc Server. This has embedded functionality of sending
 	// 4G config over REST Api as well.
-	var host string = "0.0.0.0:9876"
+	host := "0.0.0.0:9876"
 	confServ := &gServ.ConfigServer{}
 	go gServ.StartServer(host, confServ, configMsgChan)
 

--- a/configapi/api_default.go
+++ b/configapi/api_default.go
@@ -44,7 +44,7 @@ func GetDeviceGroups(c *gin.Context) {
 	setCorsHeader(c)
 	logger.WebUILog.Infoln("Get all Device Groups")
 
-	var deviceGroups []string = make([]string, 0)
+	deviceGroups := make([]string, 0)
 	rawDeviceGroups, errGetMany := dbadapter.CommonDBClient.RestfulAPIGetMany(devGroupDataColl, bson.M{})
 	if errGetMany != nil {
 		logger.DbLog.Warnln(errGetMany)
@@ -161,7 +161,7 @@ func GetNetworkSlices(c *gin.Context) {
 	setCorsHeader(c)
 	logger.WebUILog.Infoln("Get all Network Slices")
 
-	var networkSlices []string = make([]string, 0)
+	networkSlices := make([]string, 0)
 	rawNetworkSlices, errGetMany := dbadapter.CommonDBClient.RestfulAPIGetMany(sliceDataColl, bson.M{})
 	if errGetMany != nil {
 		logger.DbLog.Warnln(errGetMany)

--- a/proto/server/clientEvtHandler.go
+++ b/proto/server/clientEvtHandler.go
@@ -458,15 +458,16 @@ func clientEventMachine(client *clientNF) {
 						}
 						if !factory.WebUIConfig.Configuration.Mode5G && resp.StatusCode == http.StatusNotFound {
 							client.clientLog.Infof("Config Check Message POST to %v. Status Code -  %v \n", client.id, resp.StatusCode)
-							if client.id == "hss" {
+							switch client.id {
+							case "hss":
 								rwLock.RLock()
 								postConfigHss(client, nil, nil)
 								rwLock.RUnlock()
-							} else if client.id == "mme-app" || client.id == "mme-s1ap" {
+							case "mme-app", "mme-s1ap":
 								postConfigMme(client)
-							} else if client.id == "pcrf" {
+							case "pcrf":
 								postConfigPcrf(client)
-							} else if client.id == "spgw" {
+							case "spgw":
 								postConfigSpgw(client)
 							}
 						}
@@ -524,7 +525,8 @@ func clientEventMachine(client *clientNF) {
 			}
 			if !factory.WebUIConfig.Configuration.Mode5G {
 				// push config to 4G network functions
-				if client.id == "hss" {
+				switch client.id {
+				case "hss":
 					// client.clientLog.Debugf("Received configuration: %v", spew.Sdump(configMsg))
 					if configMsg.MsgType == configmodels.Sub_data && configMsg.MsgMethod == configmodels.Delete_op {
 						imsiVal := strings.ReplaceAll(configMsg.Imsi, "imsi-", "")
@@ -545,15 +547,15 @@ func clientEventMachine(client *clientNF) {
 						postConfigHss(client, lastDevGroup, lastSlice)
 						rwLock.RUnlock()
 					}
-				} else if client.id == "mme-app" || client.id == "mme-s1ap" {
+				case "mme-app", "mme-s1ap":
 					if (configMsg.SliceName != "") || (configMsg.DevGroupName != "") {
 						postConfigMme(client)
 					}
-				} else if client.id == "pcrf" {
+				case "pcrf":
 					if (configMsg.SliceName != "") || (configMsg.DevGroupName != "") {
 						postConfigPcrf(client)
 					}
-				} else if client.id == "spgw" {
+				case "spgw":
 					if (configMsg.SliceName != "") || (configMsg.DevGroupName != "") {
 						postConfigSpgw(client)
 					}
@@ -1129,7 +1131,8 @@ func postConfigPcrf(client *clientNF) {
 				ruleFInfo := &ruleFlowInfo{}
 				// permit out udp from 8.8.8.8/32 to assigned sport-dport
 				var desc string
-				if app.Protocol == 6 {
+				switch app.Protocol {
+				case 6:
 					if app.StartPort == 0 && app.EndPort == 0 {
 						desc = "permit out tcp from " + app.Endpoint + " to assigned"
 					} else if factory.WebUIConfig.Configuration.SdfComp {
@@ -1137,7 +1140,7 @@ func postConfigPcrf(client *clientNF) {
 					} else {
 						desc = "permit out tcp from " + app.Endpoint + " to assigned " + strconv.FormatInt(int64(app.StartPort), 10) + "-" + strconv.FormatInt(int64(app.EndPort), 10)
 					}
-				} else if app.Protocol == 17 {
+				case 17:
 					if app.StartPort == 0 && app.EndPort == 0 {
 						desc = "permit out udp from " + app.Endpoint + " to assigned"
 					} else if factory.WebUIConfig.Configuration.SdfComp {
@@ -1145,7 +1148,7 @@ func postConfigPcrf(client *clientNF) {
 					} else {
 						desc = "permit out udp from " + app.Endpoint + " to assigned " + strconv.FormatInt(int64(app.StartPort), 10) + "-" + strconv.FormatInt(int64(app.EndPort), 10)
 					}
-				} else {
+				default:
 					desc = "permit out ip from " + app.Endpoint + " to assigned"
 				}
 				ruleFInfo.FlowDesc = desc

--- a/proto/server/configEvtHandler_test.go
+++ b/proto/server/configEvtHandler_test.go
@@ -236,7 +236,7 @@ func Test_handleDeviceGroupPost(t *testing.T) {
 			t.Errorf("Expected filter %v, got %v", expected_filter, postData[0]["filter"])
 		}
 		var resultGroup configmodels.DeviceGroups
-		var result map[string]interface{} = postData[0]["data"].(map[string]interface{})
+		result := postData[0]["data"].(map[string]interface{})
 		err := json.Unmarshal(configmodels.MapToByte(result), &resultGroup)
 		if err != nil {
 			t.Errorf("Could not unmarshall result %v", result)
@@ -280,7 +280,7 @@ func Test_handleDeviceGroupPost_alreadyExists(t *testing.T) {
 			t.Errorf("Expected filter %v, got %v", expected_filter, postData[0]["filter"])
 		}
 		var resultGroup configmodels.DeviceGroups
-		var result map[string]interface{} = postData[0]["data"].(map[string]interface{})
+		result := postData[0]["data"].(map[string]interface{})
 		err := json.Unmarshal(configmodels.MapToByte(result), &resultGroup)
 		if err != nil {
 			t.Errorf("Could not unmarshall result %v", result)
@@ -387,7 +387,7 @@ func Test_handleNetworkSlicePost(t *testing.T) {
 			t.Errorf("Expected filter %v, got %v", expected_filter, postData[0]["filter"])
 		}
 		var resultSlice configmodels.Slice
-		var result map[string]interface{} = postData[0]["data"].(map[string]interface{})
+		result := postData[0]["data"].(map[string]interface{})
 		err := json.Unmarshal(configmodels.MapToByte(result), &resultSlice)
 		if err != nil {
 			t.Errorf("Could not unmarshal result %v", result)
@@ -440,7 +440,7 @@ func Test_handleNetworkSlicePost_alreadyExists(t *testing.T) {
 			t.Errorf("Expected filter %v, got %v", expected_filter, postData[0]["filter"])
 		}
 		var resultSlice configmodels.Slice
-		var result map[string]interface{} = postData[0]["data"].(map[string]interface{})
+		result := postData[0]["data"].(map[string]interface{})
 		err = json.Unmarshal(configmodels.MapToByte(result), &resultSlice)
 		if err != nil {
 			t.Errorf("Could not unmarshal result %v", result)
@@ -590,7 +590,7 @@ func Test_handleSubscriberPost5G(t *testing.T) {
 	}
 
 	var authSubResult models.AuthenticationSubscription
-	var result map[string]interface{} = postData[0]["data"].(map[string]interface{})
+	result := postData[0]["data"].(map[string]interface{})
 	err := json.Unmarshal(configmodels.MapToByte(result), &authSubResult)
 	if err != nil {
 		t.Errorf("Could not unmarshall result %v", result)
@@ -598,7 +598,7 @@ func Test_handleSubscriberPost5G(t *testing.T) {
 	if !reflect.DeepEqual(configMsg.AuthSubData, &authSubResult) {
 		t.Errorf("Expected authSubData %v, got %v", configMsg.AuthSubData, &authSubResult)
 	}
-	var amDataResult map[string]interface{} = postData[1]["data"].(map[string]interface{})
+	amDataResult := postData[1]["data"].(map[string]interface{})
 	if amDataResult["ueId"] != ueId {
 		t.Errorf("Expected ueId %v, got %v", ueId, amDataResult["ueId"])
 	}
@@ -659,7 +659,7 @@ func Test_handleSubscriberPost4G(t *testing.T) {
 		t.Errorf("Expected filter %v, got %v", expected_filter, postData[0]["filter"])
 	}
 
-	var AmDataResult map[string]interface{} = postData[0]["data"].(map[string]interface{})
+	AmDataResult := postData[0]["data"].(map[string]interface{})
 	if AmDataResult["ueId"] != ueId {
 		t.Errorf("Expected ueId %v, got %v", ueId, AmDataResult["ueId"])
 	}


### PR DESCRIPTION
This PR enables `staticcheck` linter in the CI and makes the modifications needed in the code for it to pass:
- Fix variable declarations
- Replace if with switch