### PR TITLE
chore: enable errcheck and govet in CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,9 +16,11 @@ output:
 linters:
   enable:
     - asciicheck
+    - errcheck
     - dogsled
     - godox
     - gomodguard
+    - govet
     - misspell
     - nakedret
     - predeclared
@@ -26,9 +28,6 @@ linters:
     - unconvert
     - unparam
     - whitespace
-  disable:
-    - errcheck
-    - govet
   settings:
     errcheck:
       check-type-assertions: false
@@ -62,6 +61,8 @@ linters:
         - XXX
     govet:
       enable-all: true
+      disable:
+        - fieldalignment
       settings:
         printf:
           funcs:

--- a/configapi/api_default.go
+++ b/configapi/api_default.go
@@ -79,8 +79,12 @@ func GetDeviceGroupByName(c *gin.Context) {
 	if errGetOne != nil {
 		logger.DbLog.Warnln(errGetOne)
 	}
-	json.Unmarshal(configmodels.MapToByte(rawDeviceGroup), &deviceGroup)
-
+	err := json.Unmarshal(configmodels.MapToByte(rawDeviceGroup), &deviceGroup)
+	if err != nil {
+		logger.DbLog.Errorw("failed to unmarshal device group", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve device group"})
+		return
+	}
 	if deviceGroup.DeviceGroupName == "" {
 		c.JSON(http.StatusNotFound, nil)
 	} else {
@@ -196,8 +200,12 @@ func GetNetworkSliceByName(c *gin.Context) {
 	if errGetOne != nil {
 		logger.DbLog.Warnln(errGetOne)
 	}
-	json.Unmarshal(configmodels.MapToByte(rawNetworkSlice), &networkSlice)
-
+	err := json.Unmarshal(configmodels.MapToByte(rawNetworkSlice), &networkSlice)
+	if err != nil {
+		logger.DbLog.Errorw("failed to unmarshal network slice", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve network slice"})
+		return
+	}
 	if networkSlice.SliceName == "" {
 		c.JSON(http.StatusNotFound, nil)
 	} else {

--- a/configapi/api_inventory.go
+++ b/configapi/api_inventory.go
@@ -247,10 +247,10 @@ func executeGnbTransaction(ctx context.Context, gnb configmodels.Gnb, nsOperatio
 	defer session.EndSession(ctx)
 
 	return mongo.WithSession(ctx, session, func(sc mongo.SessionContext) error {
-		if err := session.StartTransaction(); err != nil {
+		if err = session.StartTransaction(); err != nil {
 			return fmt.Errorf("failed to start transaction: %w", err)
 		}
-		if err := gnbOperation(sc, gnb); err != nil {
+		if err = gnbOperation(sc, gnb); err != nil {
 			if abortErr := session.AbortTransaction(sc); abortErr != nil {
 				logger.DbLog.Errorw("failed to abort transaction", "error", abortErr)
 			}
@@ -486,10 +486,10 @@ func executeUpfTransaction(ctx context.Context, upf configmodels.Upf, nsOperatio
 	defer session.EndSession(ctx)
 
 	return mongo.WithSession(ctx, session, func(sc mongo.SessionContext) error {
-		if err := session.StartTransaction(); err != nil {
+		if err = session.StartTransaction(); err != nil {
 			return fmt.Errorf("failed to start transaction: %w", err)
 		}
-		if err := upfOperation(sc, upf); err != nil {
+		if err = upfOperation(sc, upf); err != nil {
 			if abortErr := session.AbortTransaction(sc); abortErr != nil {
 				logger.DbLog.Errorw("failed to abort transaction", "error", abortErr)
 			}

--- a/configapi/api_inventory_test.go
+++ b/configapi/api_inventory_test.go
@@ -5,7 +5,6 @@ package configapi
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -25,15 +24,14 @@ type MockMongoClientOneGnb struct {
 func (m *MockMongoClientOneGnb) RestfulAPIGetMany(coll string, filter bson.M) ([]map[string]interface{}, error) {
 	var results []map[string]interface{}
 	var tac int32 = 123
-	gnb := configmodels.Gnb{
+	gnb := configmodels.ToBsonM(configmodels.Gnb{
 		Name: "gnb1",
 		Tac:  &tac,
+	})
+	if gnb == nil {
+		panic("failed to convert gNB to BsonM")
 	}
-	var gnbBson bson.M
-	tmp, _ := json.Marshal(gnb)
-	json.Unmarshal(tmp, &gnbBson)
-
-	results = append(results, gnbBson)
+	results = append(results, gnb)
 	return results, nil
 }
 
@@ -46,15 +44,14 @@ func (m *MockMongoClientManyGnbs) RestfulAPIGetMany(coll string, filter bson.M) 
 	names := []string{"gnb0", "gnb1", "gnb2"}
 	tacs := []int32{12, 345, 678}
 	for i, name := range names {
-		gnb := configmodels.Gnb{
+		gnb := configmodels.ToBsonM(configmodels.Gnb{
 			Name: name,
 			Tac:  &tacs[i],
+		})
+		if gnb == nil {
+			panic("failed to convert gNB to BsonM")
 		}
-		var gnbBson bson.M
-		tmp, _ := json.Marshal(gnb)
-		json.Unmarshal(tmp, &gnbBson)
-
-		results = append(results, gnbBson)
+		results = append(results, gnb)
 	}
 	return results, nil
 }
@@ -65,15 +62,14 @@ type MockMongoClientOneUpf struct {
 
 func (m *MockMongoClientOneUpf) RestfulAPIGetMany(coll string, filter bson.M) ([]map[string]interface{}, error) {
 	var results []map[string]interface{}
-	upf := configmodels.Upf{
+	upf := configmodels.ToBsonM(configmodels.Upf{
 		Hostname: "upf1",
 		Port:     "123",
+	})
+	if upf == nil {
+		panic("failed to convert UPF to BsonM")
 	}
-	var upfBson bson.M
-	tmp, _ := json.Marshal(upf)
-	json.Unmarshal(tmp, &upfBson)
-
-	results = append(results, upfBson)
+	results = append(results, upf)
 	return results, nil
 }
 
@@ -90,15 +86,14 @@ func (m *MockMongoClientManyUpfs) RestfulAPIGetMany(coll string, filter bson.M) 
 	names := []string{"upf0", "upf1", "upf2"}
 	ports := []string{"12", "345", "678"}
 	for i, name := range names {
-		upf := configmodels.Upf{
+		upf := configmodels.ToBsonM(configmodels.Upf{
 			Hostname: name,
 			Port:     ports[i],
+		})
+		if upf == nil {
+			panic("failed to convert UPF to BsonM")
 		}
-		var upfBson bson.M
-		tmp, _ := json.Marshal(upf)
-		json.Unmarshal(tmp, &upfBson)
-
-		results = append(results, upfBson)
+		results = append(results, upf)
 	}
 	return results, nil
 }

--- a/configapi/api_slice_mgmt_test.go
+++ b/configapi/api_slice_mgmt_test.go
@@ -5,6 +5,7 @@ package configapi
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -104,7 +105,10 @@ func networkSliceWithGnbParams(gnbName string, gnbTac int32) string {
 		SliceName: "slice-1",
 		SiteInfo:  siteInfo,
 	}
-	sliceTmp, _ := json.Marshal(slice)
+	sliceTmp, err := json.Marshal(slice)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal network slice: %v", err))
+	}
 	return string(sliceTmp[:])
 }
 

--- a/configapi/api_sub_config_test.go
+++ b/configapi/api_sub_config_test.go
@@ -38,11 +38,7 @@ func (m *MockMongoClientOneSubscriber) RestfulAPIGetMany(coll string, filter bso
 	subscriber := configmodels.ToBsonM(models.AccessAndMobilitySubscriptionData{})
 	subscriber["ueId"] = "208930100007487"
 	subscriber["servingPlmnId"] = "12345"
-	var subscriberBson bson.M
-	tmp, _ := json.Marshal(subscriber)
-	json.Unmarshal(tmp, &subscriberBson)
-
-	results = append(results, subscriberBson)
+	results = append(results, subscriber)
 	return results, nil
 }
 
@@ -57,10 +53,7 @@ func (m *MockMongoClientOneSubscriber) RestfulAPIGetOne(collName string, filter 
 	subscriber := configmodels.ToBsonM(models.AccessAndMobilitySubscriptionData{})
 	subscriber["ueId"] = "208930100007487"
 	subscriber["servingPlmnId"] = "12345"
-	var subscriberBson bson.M
-	tmp, _ := json.Marshal(subscriber)
-	json.Unmarshal(tmp, &subscriberBson)
-	return subscriberBson, nil
+	return subscriber, nil
 }
 
 func (m *MockMongoClientManySubscribers) RestfulAPIGetMany(coll string, filter bson.M) ([]map[string]interface{}, error) {
@@ -71,23 +64,18 @@ func (m *MockMongoClientManySubscribers) RestfulAPIGetMany(coll string, filter b
 		subscriber := configmodels.ToBsonM(models.AccessAndMobilitySubscriptionData{})
 		subscriber["ueId"] = ueId
 		subscriber["servingPlmnId"] = plmnIDs[i]
-		var subscriberBson bson.M
-		tmp, _ := json.Marshal(subscriber)
-		json.Unmarshal(tmp, &subscriberBson)
-
-		results = append(results, subscriberBson)
+		results = append(results, subscriber)
 	}
 	return results, nil
 }
 
 func (m *MockMongoClientDeviceGroupsWithSubscriber) RestfulAPIGetMany(coll string, filter bson.M) ([]map[string]interface{}, error) {
 	var results []map[string]interface{}
-	dg := deviceGroupWithImsis("group1", []string{"208930100007487", "208930100007488"})
-	var dgbson bson.M
-	tmp, _ := json.Marshal(dg)
-	json.Unmarshal(tmp, &dgbson)
-
-	results = append(results, dgbson)
+	dg := configmodels.ToBsonM(deviceGroupWithImsis("group1", []string{"208930100007487", "208930100007488"}))
+	if dg == nil {
+		panic("failed to convert device group to BsonM")
+	}
+	results = append(results, dg)
 	return results, nil
 }
 
@@ -118,7 +106,7 @@ func (m *MockAuthDBClientWithData) RestfulAPIGetOne(coll string, filter bson.M) 
 			"filter": filter,
 		})
 	}
-	authSubscription := &models.AuthenticationSubscription{
+	authSubscription := configmodels.ToBsonM(models.AuthenticationSubscription{
 		AuthenticationManagementField: "8000",
 		AuthenticationMethod:          "5G_AKA",
 		Milenage: &models.Milenage{
@@ -139,12 +127,11 @@ func (m *MockAuthDBClientWithData) RestfulAPIGetOne(coll string, filter bson.M) 
 			PermanentKeyValue:   "5122250214c33e723a5dd523fc145fc0",
 		},
 		SequenceNumber: "16f3b3f70fc2",
+	})
+	if authSubscription == nil {
+		panic("failed to convert subscriber to BsonM")
 	}
-	tmp, _ := json.Marshal(authSubscription)
-	var result map[string]interface{}
-	json.Unmarshal(tmp, &result)
-
-	return result, nil
+	return authSubscription, nil
 }
 
 type MockCommonDBClientEmpty struct {
@@ -187,7 +174,7 @@ func (m *MockCommonDBClientWithData) RestfulAPIGetOne(coll string, filter bson.M
 
 	switch coll {
 	case "subscriptionData.provisionedData.amData":
-		amDataData := models.AccessAndMobilitySubscriptionData{
+		amDataData := configmodels.ToBsonM(models.AccessAndMobilitySubscriptionData{
 			Gpsis: []string{
 				"msisdn-0900000000",
 			},
@@ -209,25 +196,25 @@ func (m *MockCommonDBClientWithData) RestfulAPIGetOne(coll string, filter bson.M
 				Downlink: "1000 Kbps",
 				Uplink:   "1000 Kbps",
 			},
+		})
+		if amDataData == nil {
+			panic("failed to convert amDataData to BsonM")
 		}
-		tmp, _ := json.Marshal(amDataData)
-		var result map[string]interface{}
-		json.Unmarshal(tmp, &result)
-		return result, nil
+		return amDataData, nil
 
 	case "policyData.ues.amData":
-		amPolicyData := models.AmPolicyData{
+		amPolicyData := configmodels.ToBsonM(models.AmPolicyData{
 			SubscCats: []string{
 				"aether",
 			},
+		})
+		if amPolicyData == nil {
+			panic("failed to convert amPolicyData to BsonM")
 		}
-		tmp, _ := json.Marshal(amPolicyData)
-		var result map[string]interface{}
-		json.Unmarshal(tmp, &result)
-		return result, nil
+		return amPolicyData, nil
 
 	case "policyData.ues.smData":
-		smPolicyData := models.SmPolicyData{
+		smPolicyData := configmodels.ToBsonM(models.SmPolicyData{
 			SmPolicySnssaiData: map[string]models.SmPolicySnssaiData{
 				"01010203": {
 					Snssai: &models.Snssai{
@@ -241,14 +228,14 @@ func (m *MockCommonDBClientWithData) RestfulAPIGetOne(coll string, filter bson.M
 					},
 				},
 			},
+		})
+		if smPolicyData == nil {
+			panic("failed to convert smPolicyData to BsonM")
 		}
-		tmp, _ := json.Marshal(smPolicyData)
-		var result map[string]interface{}
-		json.Unmarshal(tmp, &result)
-		return result, nil
+		return smPolicyData, nil
 
 	case "subscriptionData.provisionedData.smfSelectionSubscriptionData":
-		smfSelData := models.SmfSelectionSubscriptionData{
+		smfSelData := configmodels.ToBsonM(models.SmfSelectionSubscriptionData{
 			SubscribedSnssaiInfos: map[string]models.SnssaiInfo{
 				"01010203": {
 					DnnInfos: []models.DnnInfo{
@@ -258,11 +245,11 @@ func (m *MockCommonDBClientWithData) RestfulAPIGetOne(coll string, filter bson.M
 					},
 				},
 			},
+		})
+		if smfSelData == nil {
+			panic("failed to convert smfSelData to BsonM")
 		}
-		tmp, _ := json.Marshal(smfSelData)
-		var result map[string]interface{}
-		json.Unmarshal(tmp, &result)
-		return result, nil
+		return smfSelData, nil
 
 	default:
 		return nil, fmt.Errorf("collection %s not found", coll)
@@ -497,30 +484,42 @@ func TestGetSubscriberByID(t *testing.T) {
 			}
 
 			responseContent := w.Body.String()
-			var actual, expected map[string]interface{}
+			var actual map[string]interface{}
 			if err := json.Unmarshal([]byte(responseContent), &actual); err != nil {
 				t.Fatalf("Failed to unmarshal actual response: %v. Raw response: %s", err, responseContent)
 			}
-			expectedJSON, _ := json.Marshal(tt.expectedFullResponse)
-			_ = json.Unmarshal(expectedJSON, &expected)
-
-			expectedResponse, _ := json.Marshal(expected)
-			actualResponse, _ := json.Marshal(actual)
-
+			expectedResponse, err := json.Marshal(tt.expectedFullResponse)
+			if err != nil {
+				t.Fatalf("failed to marshal expected response: %v", err)
+			}
+			actualResponse, err := json.Marshal(actual)
+			if err != nil {
+				t.Fatalf("failed to marshal actual response: %v", err)
+			}
 			if !reflect.DeepEqual(expectedResponse, actualResponse) {
 				t.Errorf("Mismatch in response:\nExpected:\n%s\nGot:\n%s\n", string(expectedResponse), string(actualResponse))
 			}
 
-			expectedCommonData, _ := json.Marshal(tt.expectedCommonPostDataDetails)
-			gotCommonData, _ := json.Marshal(postDataCommon)
-
+			expectedCommonData, err := json.Marshal(tt.expectedCommonPostDataDetails)
+			if err != nil {
+				t.Fatalf("failed to marshal expected post data details: %v", err)
+			}
+			gotCommonData, err := json.Marshal(postDataCommon)
+			if err != nil {
+				t.Fatalf("failed to marshal actual post data details: %v", err)
+			}
 			if !reflect.DeepEqual(expectedCommonData, gotCommonData) {
 				t.Errorf("Expected CommonPostData `%v`, but got `%v`", tt.expectedCommonPostDataDetails, postDataCommon)
 			}
 
-			expectedAuthData, _ := json.Marshal(tt.expectedAuthPostDataDetails)
-			gotAuthData, _ := json.Marshal(postDataAuth)
-
+			expectedAuthData, err := json.Marshal(tt.expectedAuthPostDataDetails)
+			if err != nil {
+				t.Fatalf("failed to marshal expected auth post data details: %v", err)
+			}
+			gotAuthData, err := json.Marshal(postDataAuth)
+			if err != nil {
+				t.Fatalf("failed to marshal actual auth post data details: %v", err)
+			}
 			if !reflect.DeepEqual(expectedAuthData, gotAuthData) {
 				t.Errorf("Expected AuthPostData `%v`, but got `%v`", tt.expectedAuthPostDataDetails, postDataAuth)
 			}
@@ -665,9 +664,14 @@ func TestSubscriberPostHandlersNoExistingSubscriber(t *testing.T) {
 		t.Errorf("Expected `%v`, got `%v`", expectedBody, w.Body.String())
 	}
 
-	expectedCommonData, _ := json.Marshal(expectedCommonPostDataDetails)
-	gotCommonData, _ := json.Marshal(postDataCommon)
-
+	expectedCommonData, err := json.Marshal(expectedCommonPostDataDetails)
+	if err != nil {
+		t.Fatalf("failed to marshal expected post data details: %v", err)
+	}
+	gotCommonData, err := json.Marshal(postDataCommon)
+	if err != nil {
+		t.Fatalf("failed to marshal actual post data details: %v", err)
+	}
 	if !reflect.DeepEqual(expectedCommonData, gotCommonData) {
 		t.Errorf("Expected CommonPostData `%v`, but got `%v`", expectedCommonPostDataDetails, postDataCommon)
 	}
@@ -738,9 +742,14 @@ func TestSubscriberPostHandlersSubscriberExists(t *testing.T) {
 		t.Errorf("Expected `%v`, got `%v`", expectedBody, w.Body.String())
 	}
 
-	expectedCommonData, _ := json.Marshal(expectedCommonPostDataDetails)
-	gotCommonData, _ := json.Marshal(postDataCommon)
-
+	expectedCommonData, err := json.Marshal(expectedCommonPostDataDetails)
+	if err != nil {
+		t.Fatalf("failed to marshal expected post data details: %v", err)
+	}
+	gotCommonData, err := json.Marshal(postDataCommon)
+	if err != nil {
+		t.Fatalf("failed to marshal actual post data details: %v", err)
+	}
 	if !reflect.DeepEqual(expectedCommonData, gotCommonData) {
 		t.Errorf("Expected CommonPostData `%v`, but got `%v`", expectedCommonPostDataDetails, postDataCommon)
 	}


### PR DESCRIPTION
This PR enables `errcheck` and `govet` linters in the CI and makes the modifications needed in the code for it to pass:
- Handle errors in `json.Marshal` and `json.Unmarshal` operations
- Remove unnecessary marshal-unmarshal of test params using `configmodels.ToBsonM`
- Handle errors in io.ReadAll(resp.Body)
- Avoid variable shadowing over `err` by removing the `:`

Note: fieldaligment in govet is disabled but all the other checks are enabled