### PR TITLE
fix: remove blocking sleep in sync in-memory config retry

### DIFF
--- a/backend/nfconfig/service.go
+++ b/backend/nfconfig/service.go
@@ -123,19 +123,19 @@ func (n *NFConfigServer) syncWithRetry(ctx context.Context) {
 	n.syncMutex.Lock()
 	defer n.syncMutex.Unlock()
 	logger.NfConfigLog.Debugln("Starting in-memory NF configuration synchronization with new context")
-
+	interval := 0 * time.Second
 	for {
 		select {
 		case <-ctx.Done():
 			logger.NfConfigLog.Infoln("No-op. Sync in-memory configuration was cancelled")
 			return
-		default:
+		case <-time.After(interval):
 			err := syncInMemoryConfigFunc(n)
 			if err == nil {
 				return
 			}
 			logger.NfConfigLog.Warnf("Sync in-memory configuration failed, retrying: %v", err)
-			time.Sleep(3 * time.Second)
+			interval = 3 * time.Second
 		}
 	}
 }

--- a/server.go
+++ b/server.go
@@ -84,7 +84,7 @@ func startApplication(config *factory.Config) error {
 func runWebUIAndNFConfig(webui webui_service.WebUIInterface, nfConf nfconfig.NFConfigInterface) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	syncChan := make(chan struct{}, 1)
+	syncChan := make(chan struct{}, 5)
 	go webui.Start(ctx, syncChan)
 	logger.InitLog.Infoln("WebUI started")
 

--- a/server.go
+++ b/server.go
@@ -84,7 +84,7 @@ func startApplication(config *factory.Config) error {
 func runWebUIAndNFConfig(webui webui_service.WebUIInterface, nfConf nfconfig.NFConfigInterface) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	syncChan := make(chan struct{}, 5)
+	syncChan := make(chan struct{}, 1)
 	go webui.Start(ctx, syncChan)
 	logger.InitLog.Infoln("WebUI started")
 


### PR DESCRIPTION
## Description

Using sleep in the retry function when syncing the in-memory configuration blocks the program in case of cancellation due to a new config. This PR uses the select `case <-time.After(interval)` instead.