### PR TITLE
chore: add E2E tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,3 +54,8 @@ jobs:
     uses: omec-project/.github/.github/workflows/unit-test.yml@main
     with:
       branch_name: ${{ github.ref }}
+
+  e2e-tests:
+    uses: omec-project/.github/.github/workflows/e2e-test.yml@main
+    with:
+      branch_name: ${{ github.ref }}


### PR DESCRIPTION
Run E2E tests as part of CI process. Hence, we make sure that integrations tests will pass without manual testing.