### PR TITLE
fix: upf port can be a int or float64

### DIFF
--- a/backend/nfconfig/config_session_management_test.go
+++ b/backend/nfconfig/config_session_management_test.go
@@ -21,7 +21,7 @@ type networkSliceParams struct {
 	sd           string
 	deviceGroups []string
 	upfHostname  any
-	upfPort      string
+	upfPort      any
 	gnbNames     []string
 }
 
@@ -434,6 +434,74 @@ func TestSyncSessionManagement(t *testing.T) {
 						Sd:  sharedSd,
 					},
 					Upf:      nil,
+					GnbNames: []string{"gnb-1"},
+				},
+			},
+		},
+		{
+			name: "int upf port",
+			sliceParams: []networkSliceParams{
+				{
+					sliceName:    "slice-4",
+					mcc:          "001",
+					mnc:          "01",
+					sst:          "1",
+					sd:           "010203",
+					upfHostname:  "hostname.com",
+					upfPort:      1234,
+					deviceGroups: []string{"dg-1"},
+					gnbNames:     []string{"gnb-1"},
+				},
+			},
+			expectedResponse: []nfConfigApi.SessionManagement{
+				{
+					SliceName: "slice-4",
+					PlmnId: nfConfigApi.PlmnId{
+						Mcc: "001",
+						Mnc: "01",
+					},
+					Snssai: nfConfigApi.Snssai{
+						Sst: 1,
+						Sd:  sharedSd,
+					},
+					Upf: &nfConfigApi.Upf{
+						Hostname: "hostname.com",
+						Port:     ptr(int32(1234)),
+					},
+					GnbNames: []string{"gnb-1"},
+				},
+			},
+		},
+		{
+			name: "float upf port",
+			sliceParams: []networkSliceParams{
+				{
+					sliceName:    "slice-4",
+					mcc:          "001",
+					mnc:          "01",
+					sst:          "1",
+					sd:           "010203",
+					upfHostname:  "hostname.com",
+					upfPort:      1234.00,
+					deviceGroups: []string{"dg-1"},
+					gnbNames:     []string{"gnb-1"},
+				},
+			},
+			expectedResponse: []nfConfigApi.SessionManagement{
+				{
+					SliceName: "slice-4",
+					PlmnId: nfConfigApi.PlmnId{
+						Mcc: "001",
+						Mnc: "01",
+					},
+					Snssai: nfConfigApi.Snssai{
+						Sst: 1,
+						Sd:  sharedSd,
+					},
+					Upf: &nfConfigApi.Upf{
+						Hostname: "hostname.com",
+						Port:     ptr(int32(1234)),
+					},
 					GnbNames: []string{"gnb-1"},
 				},
 			},


### PR DESCRIPTION
# Description

Given that the UPF field in the network slices is defined as 
```
	Upf map[string]interface{} `json:"upf,omitempty"`
```
and can be initialized as:
```
 map[string]interface{}{
			"upf-name": "some hostname",
			"upf-port": port,
		}
```

It is not clear what the type for the `upf-port` is. 

This PR extends the possibility of the port to also be a float64 (default type when unmarshaling), int.